### PR TITLE
Catalog skeleton loader

### DIFF
--- a/frontend/poletto_skins/src/components/Catalog/index.tsx
+++ b/frontend/poletto_skins/src/components/Catalog/index.tsx
@@ -1,8 +1,8 @@
 import './styles.scss'
 
 import { ItemType } from '@/types/entities/item'
-import { Box, Grid } from '@mui/material'
-import { useState } from 'react'
+import { Box, Grid, Skeleton } from '@mui/material'
+import { useEffect, useState } from 'react'
 import ItemCard from '../ItemCard'
 import ItemModal from '../ItemModal'
 
@@ -11,6 +11,14 @@ type CatalogProps = {
 }
 
 const Catalog = ({ items }: CatalogProps) => {
+
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        if (items && items.length > 0) {
+            setLoading(false)
+        }
+    }, [items])
 
     const [selectedItem, setSelectedItem] = useState<ItemType>()
 
@@ -32,11 +40,17 @@ const Catalog = ({ items }: CatalogProps) => {
 
             <Box sx={{ flexGrow: 1 }}>
                 <Grid container justifyContent='space-between' spacing={1} columns={{ xs: 4, sm: 8, md: 12, lg: 12, xl: 16 }}>
-                    {items.map((item, index) => (
-                        <Grid item xs={2} sm={4} md={4} lg={3} key={index}>
-                            <ItemCard itemProps={item} key={item.id} openModal={() => handleOpen(item)} />
-                        </Grid>
-                    ))}
+                    {loading
+                        ? Array.from(new Array(12)).map((_, index) => (
+                            <Grid item xs={2} sm={4} md={4} lg={3} key={index} >
+                                <Skeleton variant='rounded' animation='wave' height='344px' />
+                            </Grid>
+                        ))
+                        : items.map((item, index) => (
+                            <Grid item xs={2} sm={4} md={4} lg={3} key={index}>
+                                <ItemCard itemProps={item} key={item.id} openModal={() => handleOpen(item)} />
+                            </Grid>
+                        ))}
                 </Grid>
             </Box>
 

--- a/frontend/poletto_skins/src/components/Catalog/styles.scss
+++ b/frontend/poletto_skins/src/components/Catalog/styles.scss
@@ -8,6 +8,7 @@ $thumb-radius: 5px;
     flex-direction: row;
     overflow: auto;
     height: 100%;
+    width: 100%;
     padding-right: 16px;
     scrollbar-gutter: stable;
 

--- a/frontend/poletto_skins/src/components/MainFilter/styles.scss
+++ b/frontend/poletto_skins/src/components/MainFilter/styles.scss
@@ -9,7 +9,7 @@ $thumb-radius: 5px;
     display: flex;
     flex-direction: column;
     min-width: 175px;
-    min-width: 175px;
+    max-width: 175px;
     gap: 20px;
 
     .upper-area {

--- a/frontend/poletto_skins/src/components/TopFilter/styles.scss
+++ b/frontend/poletto_skins/src/components/TopFilter/styles.scss
@@ -2,6 +2,7 @@
     display: flex;
     flex-direction: row;
     height: 34px;
+    padding-right: 21px;
     justify-content: space-between;
 
     .left-container {

--- a/frontend/poletto_skins/src/pages/Buy/styles.scss
+++ b/frontend/poletto_skins/src/pages/Buy/styles.scss
@@ -15,10 +15,12 @@
         flex-direction: column;
         gap: 10px;
         height: 100%;
+        width: 100%;
 
         .catalog-container {
             display: flex;
             height: 100%;
+            width: 100%;
             overflow-y: hidden;
             overflow-x: hidden;
         }


### PR DESCRIPTION
Esse pull request integra as alterações feitas na branch catalog-skeleton-loader que incluem mas não se limitam a:

* Adicionar os SkeletonLoaders da MUI no lugar dos itens no catálogo enquanto os itens carregam, os parâmetros de responsividade dos itens e do layout são iguais aos dos itens em si 12b708e
![image](https://github.com/crysisprophet1234/poletto-skins/assets/117860590/50e6ce2b-a3a2-4d2e-967c-e4a615d67be6)

* Corrige width nos containers que recebem o componente Catalog, no próprio catalog e nos parentes como no caso o Buy. A correção no caso é permitir que esses containers sempre se expandam ao espaço máximo restante do componente parente 65e8c85

* Corrigindo pad-right do TopFilter para fazer com que o Select das opções de Sorting fique alinhado ao componente Catalog.