### PR TITLE
Creating items cart

### DIFF
--- a/frontend/poletto_skins/src/App.tsx
+++ b/frontend/poletto_skins/src/App.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 
 import { lazy, Suspense } from 'react'
 import './assets/styles/global.scss'
+import { CartProvider } from './contexts/CartContext'
 import ErrorPage from './pages/ErrorPage'
 import Sell from './pages/Sell'
 import Root from './routes/root'
@@ -27,7 +28,9 @@ const router = createBrowserRouter([
         element:
           <Suspense
             fallback={<h1>Loading...</h1>}>
-            <Buy />
+            <CartProvider>
+              <Buy />
+            </CartProvider>
           </Suspense>
       },
       {
@@ -45,9 +48,9 @@ const router = createBrowserRouter([
 const App = () => {
 
   return (
-    <>
-      <RouterProvider router={router} />
-    </>
+
+    <RouterProvider router={router} />
+
   )
 }
 

--- a/frontend/poletto_skins/src/components/AddCartButton/index.tsx
+++ b/frontend/poletto_skins/src/components/AddCartButton/index.tsx
@@ -1,11 +1,14 @@
-import { AddShoppingCartRounded } from '@mui/icons-material'
+import { AddShoppingCartRounded, RemoveShoppingCartRounded } from '@mui/icons-material'
 import { Box, Button } from '@mui/material'
 
 type AddCartButtonProps = {
-    onClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+    isItemInCart: boolean
+    onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 }
 
-const AddCartButton = ({ onClick }: AddCartButtonProps) => {
+const AddCartButton = ({ isItemInCart, onClick }: AddCartButtonProps) => {
+
+    //TODO: colors are batshit as of rn because of how the color is changed when hovering parent
 
     return (
 
@@ -14,34 +17,36 @@ const AddCartButton = ({ onClick }: AddCartButtonProps) => {
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
-                width: '100%',
+                //width: '100%',
+                height: '100%',
                 cursor: 'pointer',
-                backgroundColor: '#292733',
+                backgroundColor: isItemInCart ? '#f05f75' : '#292733',
                 borderRadius: '0.25rem',
                 transition: 'background-color 0.3s ease-in-out',
                 '&:hover': {
-                    backgroundColor: '#C85CD1 !important',
-                    boxShadow: '0 0 10px rgba(200, 92, 209, 0.8), 0 0 15px rgba(200, 92, 209, 0.6), 0 0 20px rgba(200, 92, 209, 0.4)',
+                    backgroundColor: isItemInCart ? '#ff8095 !important' : '#C85CD1 !important',
+                    //boxShadow: '0 0 10px rgba(200, 92, 209, 0.8), 0 0 15px rgba(200, 92, 209, 0.6), 0 0 20px rgba(200, 92, 209, 0.4)',
                 }
             }}
-            onClick={(e) => onClick(e)}
+            onClick={onClick}
         >
             <Button
                 sx={{
                     display: 'flex',
                     justifyContent: 'center',
                     alignItems: 'center',
-                    width: '100%',
+                    //width: '100%',
                     height: '100%',
                     minWidth: 0,
                     padding: '6px',
+                    color: '#FFF',
                     backgroundColor: 'transparent',
                     '&:hover': {
                         backgroundColor: 'transparent',
                     }
                 }}
             >
-                <AddShoppingCartRounded sx={{ fill: '#FFF' }} />
+                {isItemInCart ? <RemoveShoppingCartRounded /> : <AddShoppingCartRounded />}
             </Button>
         </Box>
 

--- a/frontend/poletto_skins/src/components/Cart/ItemCartPopup/ItemCartMiniature/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/ItemCartPopup/ItemCartMiniature/index.tsx
@@ -1,0 +1,114 @@
+import { ItemType } from '@/types/entities/item'
+import { Box, Paper, Stack, Tooltip, Typography } from '@mui/material'
+import { useCart } from '../../../../hooks/useCart'
+import AddCartButton from '../../../AddCartButton'
+
+type ItemCartMiniatureProps = {
+    item: ItemType
+}
+
+const ItemCartMiniature = ({ item }: ItemCartMiniatureProps) => {
+
+    const { removeFromCart } = useCart()
+
+    const imageDimensions = {
+        width: 115,
+        height: 90
+    }
+
+    return (
+
+        <Paper
+            elevation={3}
+            sx={{
+                width: '100%',
+                bgcolor: '#1c1a24',
+                padding: 2,
+                color: '#FFF'
+            }}
+        >
+            <Stack
+                direction='column'
+                gap={1}
+                width={imageDimensions.width}
+            >
+
+                <Box
+                    sx={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'center'
+                    }}
+                >
+                    <img
+                        src={`${item.imageUrl}/${imageDimensions.width}fx${imageDimensions.height}f`}
+                        alt={item.name}
+                        loading='lazy'
+                        style={{
+                            width: '100%',
+                            height: '100%',
+                            objectFit: 'fill'
+                        }}
+                    />
+
+                </Box>
+
+                <Box>
+
+                    <Tooltip
+                        placement='top'
+                        arrow
+                        title={
+                            <Typography>
+                                {`${'subCategory' in item ? item.subCategory : item.category} | ${item.name}`}
+                            </Typography>
+                        }
+                    >
+                        <Typography noWrap fontSize={'14px'}>
+                            {`${'subCategory' in item ? item.subCategory : ''} ${item.name}`}
+                        </Typography>
+                    </Tooltip>
+
+                    <Stack direction={'row'} justifyContent={'space-between'} fontSize={'14px'}>
+
+                        {'statTrak' in item &&
+                            <Typography color='#CF6A32' fontSize={'14px'}>
+                                ST
+                            </Typography>
+                        }
+
+                        {'floatShort' in item &&
+                            <Typography fontSize={'14px'}>
+                                {item.floatShort}
+                            </Typography>
+                        }
+
+                        {'floatFull' in item &&
+                            <Typography fontSize={'14px'}>
+                                {item.floatFull.toFixed(4)}
+                            </Typography>
+                        }
+
+                        {'finish' in item &&
+                            <Typography fontSize={'14px'}>
+                                {item.finish}
+                            </Typography>
+                        }
+
+                    </Stack>
+
+                </Box>
+
+                <Box height={'28px'}>
+                    <AddCartButton isItemInCart={true} onClick={() => removeFromCart(item.id)} />
+                </Box>
+
+            </Stack >
+
+        </Paper >
+
+    )
+
+}
+
+export default ItemCartMiniature

--- a/frontend/poletto_skins/src/components/Cart/ItemCartPopup/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/ItemCartPopup/index.tsx
@@ -1,0 +1,168 @@
+import { AddShoppingCartRounded, Close } from '@mui/icons-material'
+import { Box, Button, Grid, IconButton, Paper, Stack, Typography } from '@mui/material'
+import { useCart } from '../../../hooks/useCart'
+import ItemCartMiniature from './ItemCartMiniature'
+
+type ItemCartPopupProps = {
+    onClose: () => void
+}
+
+const ItemCartPopup = ({ onClose }: ItemCartPopupProps) => {
+
+    const { cart, totalItems } = useCart()
+
+    return (
+        <Paper
+            sx={{
+                width: '515px',
+                marginTop: 1,
+                bgcolor: '#403D4D',
+                paddingY: 2,
+                paddingLeft: '24px',
+                paddingRight: '12px',
+                color: '#FFF'
+            }}
+        >
+            <Stack
+                direction={'column'}
+                gap={1}
+            >
+                <Box
+                    sx={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        paddingRight: '8px'
+                    }}
+                >
+
+                    <Box>
+                        <Typography
+                            variant='h5'
+                        >
+                            Carrinho
+                        </Typography>
+                        <Typography
+                            variant='body2'
+                            color={'#BCBCC2'}
+                        >
+                            Total items: {totalItems}
+                        </Typography>
+                    </Box>
+
+                    <IconButton
+                        onClick={onClose}
+                    >
+                        <Close
+                            fontSize='large'
+                            sx={{
+                                fill: '#817e8f',
+                                '&:hover': {
+                                    fill: '#bbb9c7'
+                                }
+                            }}
+                        />
+                    </IconButton>
+
+                </Box>
+
+                <Box>
+
+                    {totalItems == 0
+                        ? (
+                            <Stack
+                                gap={1}
+                                direction='column'
+                                alignItems='center'
+                            >
+                                <AddShoppingCartRounded sx={{ fontSize: '50px' }} />
+
+                                <Typography
+                                    variant='body1'
+                                    fontWeight='bold'
+                                >
+                                    Seu carrinho está vazio!
+                                </Typography>
+
+                                <Typography
+                                    variant='body2'
+                                >
+                                    Os itens do mercado adicionados ao carrinho serão mostrados aqui.
+                                </Typography>
+
+                            </Stack>
+                        ) : (
+                            <Box
+                                sx={{
+                                    overflowY: 'auto',
+                                    overflowX: 'hidden',
+                                    maxHeight: '605px',
+                                    paddingRight: '12px',
+                                    scrollbarGutter: 'stable',
+                                    scrollbarColor: '#555261',
+                                    '&::-webkit-scrollbar': {
+                                        width: '5px',
+                                        borderRadius: '5px'
+                                    },
+                                    '&::-webkit-scrollbar-thumb': {
+                                        backgroundColor: '#C85CD1',
+                                        borderRadius: '5px'
+                                    },
+                                    '&::-webkit-scrollbar-track': {
+                                        backgroundColor: '#555261',
+                                        borderRadius: '5px'
+                                    },
+                                    '&::-webkit-scrollbar-thumb:hover': {
+                                        backgroundColor: '#D63FE9'
+                                    }
+                                }}
+                            >
+                                <Grid container spacing={1} columns={3} >
+
+                                    {cart.map((item, index) => (
+                                        <Grid item key={index} sm={1}>
+                                            <ItemCartMiniature item={item} />
+                                        </Grid>
+                                    ))}
+
+                                </Grid>
+                            </Box>
+                        )
+                    }
+
+                </Box>
+
+                <Box mt={1}>
+                    <Button
+                        onClick={
+                            totalItems == 0
+                                ? () => onClose()
+                                : () => alert('not implemented yet')
+                        }
+                        sx={{
+                            color: '#FFF',
+                            fontWeight: 'bold',
+                            backgroundColor: '#806cf5',
+                            width: 'calc(100% - 16px)',
+                            '&:hover': {
+                                backgroundColor: '#9F8FFF'
+                            }
+                        }}
+                    >
+                        {
+                            totalItems > 0
+                                ? 'Finalizar compra'
+                                : 'Ir para o Mercado'
+                        }
+                    </Button>
+                </Box>
+
+            </Stack>
+
+        </Paper>
+    )
+
+}
+
+export default ItemCartPopup

--- a/frontend/poletto_skins/src/components/Cart/ShowCartButton/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/ShowCartButton/index.tsx
@@ -1,0 +1,59 @@
+import { ShoppingCart } from '@mui/icons-material'
+import { Badge, Button, Typography } from '@mui/material'
+import { useCart } from '../../../hooks/useCart'
+
+type ShowCartButtonProps = {
+    handleClick: (e: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+const ShowCartButton = ({ handleClick }: ShowCartButtonProps) => {
+
+    const { totalItems, totalPrice } = useCart()
+
+    return (
+
+        <Button
+            onClick={handleClick}
+            sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                alignContent: 'center',
+                gap: '10px',
+                color: '#FFF',
+                height: '100%',
+                minWidth: 'fit-content',
+                flex: 1,
+                cursor: 'pointer',
+                paddingX: '16px',
+                paddingY: '6px',
+                backgroundColor: totalItems > 0 ? '#806cf5' : '#403D4D',
+                '&:hover': {
+                    backgroundColor: totalItems > 0 ? '#9f8fff' : '#5A5565'
+                }
+            }}
+        >
+            <>
+                <Typography lineHeight={1} fontWeight={500}>
+                    R$ {totalPrice.toFixed(2)}
+                </Typography>
+                <Badge badgeContent={totalItems} max={9} sx={{
+                    '& .MuiBadge-badge': {
+                        top: '5.5px',
+                        right: '-3px',
+                        fontSize: '12px',
+                        backgroundColor: '#5f2cff',
+                        padding: .5,
+                        minWidth: '16px', // Adjust width as needed
+                        height: '16px'
+                    }
+                }}>
+                    <ShoppingCart />
+                </Badge>
+            </>
+        </Button>
+
+    )
+}
+
+export default ShowCartButton

--- a/frontend/poletto_skins/src/components/Cart/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/index.tsx
@@ -1,0 +1,45 @@
+import { Box, ClickAwayListener, Popper } from '@mui/material'
+import { useState } from 'react'
+import ItemCartPopup from './ItemCartPopup'
+import ShowCartButton from './ShowCartButton'
+
+const Cart = () => {
+
+    const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
+    const [open, setOpen] = useState(false)
+
+    const handleOutsideClick = () => {
+        setOpen(false)
+    }
+
+    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+        setAnchorEl(event.currentTarget)
+        setOpen(!open)
+    }
+
+    return (
+
+        <ClickAwayListener onClickAway={handleOutsideClick}>
+
+            <Box>
+
+                <ShowCartButton handleClick={handleClick} />
+
+                <Popper
+                    id='cart-popper'
+                    placement='bottom-end'
+                    open={open}
+                    anchorEl={anchorEl}
+                >
+                    <ItemCartPopup onClose={() => setOpen(false)} />
+                </Popper>
+
+            </Box>
+
+        </ClickAwayListener >
+
+    )
+
+}
+
+export default Cart

--- a/frontend/poletto_skins/src/components/Catalog/index.tsx
+++ b/frontend/poletto_skins/src/components/Catalog/index.tsx
@@ -8,9 +8,10 @@ import ItemModal from '../ItemModal'
 
 type CatalogProps = {
     items: ItemType[]
+    itemAction: (item: ItemType) => void
 }
 
-const Catalog = ({ items }: CatalogProps) => {
+const Catalog = ({ items, itemAction }: CatalogProps) => {
 
     const [loading, setLoading] = useState(true)
 
@@ -43,12 +44,21 @@ const Catalog = ({ items }: CatalogProps) => {
                     {loading
                         ? Array.from(new Array(12)).map((_, index) => (
                             <Grid item xs={2} sm={4} md={4} lg={3} key={index} >
-                                <Skeleton variant='rounded' animation='wave' height='344px' />
+                                <Skeleton
+                                    variant='rounded'
+                                    animation='wave'
+                                    height='344px'
+                                />
                             </Grid>
                         ))
                         : items.map((item, index) => (
                             <Grid item xs={2} sm={4} md={4} lg={3} key={index}>
-                                <ItemCard itemProps={item} key={item.id} openModal={() => handleOpen(item)} />
+                                <ItemCard
+                                    itemProps={item}
+                                    key={item.id}
+                                    itemAction={() => itemAction(item)}
+                                    openModal={() => handleOpen(item)}
+                                />
                             </Grid>
                         ))}
                 </Grid>
@@ -57,6 +67,7 @@ const Catalog = ({ items }: CatalogProps) => {
             {selectedItem &&
                 <ItemModal
                     open={open}
+                    itemAction={() => itemAction(selectedItem)}
                     handleClose={handleClose}
                     item={selectedItem}
                 />

--- a/frontend/poletto_skins/src/components/FormComponents/FormQuerySearchText/index.tsx
+++ b/frontend/poletto_skins/src/components/FormComponents/FormQuerySearchText/index.tsx
@@ -24,8 +24,11 @@ const theme = createTheme({
             styleOverrides: {
                 root: {
                     height: '100%',
+                    minWidth: '380px',
+                    maxWidth: '380px',
                     backgroundColor: '#403D4D',
-                    borderRadius: '.25rem'
+                    borderRadius: '.25rem',
+                    paddingRight: '10px'
                 },
             }
         },

--- a/frontend/poletto_skins/src/components/ItemCard/index.tsx
+++ b/frontend/poletto_skins/src/components/ItemCard/index.tsx
@@ -4,14 +4,18 @@ import { ItemType } from '@/types/entities/item'
 import { useEffect, useState } from 'react'
 import { FaSteam } from 'react-icons/fa6'
 import { MdFavorite } from 'react-icons/md'
+import { useCart } from '../../hooks/useCart'
 import AddCartButton from '../AddCartButton'
 
 type ItemCardProps = {
     itemProps: ItemType
     openModal: () => void
+    itemAction: () => void
 }
 
-const ItemCard = ({ itemProps, openModal }: ItemCardProps) => {
+const ItemCard = ({ itemProps, openModal, itemAction }: ItemCardProps) => {
+
+    const { isItemInCart } = useCart()
 
     const [item, setItem] = useState<ItemType | null>(null)
 
@@ -115,13 +119,13 @@ const ItemCard = ({ itemProps, openModal }: ItemCardProps) => {
 
                 </div>
 
-                <div className='add-cart-container'>
-                    <AddCartButton onClick={(e) => { e.stopPropagation() }} />
+                <div className='add-cart-container' onClick={(e) => e.stopPropagation()}>
+                    <AddCartButton isItemInCart={isItemInCart(item.id)} onClick={itemAction} />
                 </div>
 
             </div>
 
-        </div>
+        </div >
     )
 }
 

--- a/frontend/poletto_skins/src/components/ItemCard/styles.scss
+++ b/frontend/poletto_skins/src/components/ItemCard/styles.scss
@@ -199,9 +199,11 @@ $primary-box-shadow-hover: 0 0 10px $accent-color, 0 0 15px rgba($accent-color, 
         }
     }
 
+    /*TODO: how to use this without breaking the red collor that removes items from the cart?
     &:hover {
         .item-bottom-container .add-cart-container div {
             background-color: $secondary-color;
         }
     }
+        */
 }

--- a/frontend/poletto_skins/src/components/ItemModal/index.tsx
+++ b/frontend/poletto_skins/src/components/ItemModal/index.tsx
@@ -7,6 +7,7 @@ import Box from '@mui/material/Box'
 import Modal from '@mui/material/Modal'
 import Typography from '@mui/material/Typography'
 import { FaExternalLinkAlt } from 'react-icons/fa'
+import { useCart } from '../../hooks/useCart'
 import AddCartButton from '../AddCartButton'
 import FloatBar from '../FloatBar'
 
@@ -14,9 +15,12 @@ type ItemModalProps = {
     item: ItemType
     open: boolean
     handleClose: () => void
+    itemAction: () => void
 }
 
-const ItemModal = ({ item, open, handleClose }: ItemModalProps) => {
+const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
+
+    const { isItemInCart } = useCart()
 
     const fullFloatCategoryName = (floatShort: string) => {
         switch (floatShort.toLocaleLowerCase()) {
@@ -290,7 +294,7 @@ const ItemModal = ({ item, open, handleClose }: ItemModalProps) => {
                                 </div>
 
                                 <div className='add-cart-container'>
-                                    <AddCartButton onClick={() => {/* TODO: implement logic */ }} />
+                                    <AddCartButton isItemInCart={isItemInCart(item.id)} onClick={itemAction} />
                                 </div>
 
                             </div>

--- a/frontend/poletto_skins/src/components/ItemModal/styles.scss
+++ b/frontend/poletto_skins/src/components/ItemModal/styles.scss
@@ -123,11 +123,13 @@ $item-value-text-color: #BCBCC2;
         gap: 20px;
     }
 
+    /*TODO: how to use this without breaking the red collor that removes items from the cart?
     .add-cart-container {
         div {
             background-color: $secondary-color;
         }
     }
+        */
 
     .item-info {
         display: flex;

--- a/frontend/poletto_skins/src/components/TopFilter/index.tsx
+++ b/frontend/poletto_skins/src/components/TopFilter/index.tsx
@@ -4,10 +4,11 @@ import { debounce } from '@mui/material'
 import { useEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
+import Cart from '../Cart'
 import FormSearchQueryText from '../FormComponents/FormQuerySearchText'
-import FormSelect from '../FormComponents/FormSelect'
 import FormToggleButton from '../FormComponents/FormToggleButton'
 import './styles.scss'
+import FormSelect from '../FormComponents/FormSelect'
 
 const sortOptions = [
     {
@@ -84,13 +85,20 @@ const TopFilter = ({ onFilterChange }: TopFilterProps) => {
 
         <div className='filter-top-container'>
 
-            <div className='left-container'>
-
+            <div className='filter-top-section'>
                 <FormSearchQueryText
                     name='query'
                     control={control}
                     label='query search'
                     placeholder='Busque o nome do item, skin, sticker...'
+                />
+
+                <FormSelect
+                    name='sort'
+                    control={control}
+                    label='sort'
+                    options={sortOptions}
+                    placeholder='Padrão'
                 />
 
                 <FormToggleButton
@@ -101,18 +109,11 @@ const TopFilter = ({ onFilterChange }: TopFilterProps) => {
 
             </div>
 
-            <div className='sort-container'>
+            <div className='filter-top-section'>
 
-                <FormSelect
-                    name='sort'
-                    control={control}
-                    label='sort'
-                    options={sortOptions}
-                    placeholder='Padrão'
-                />
+                <Cart />
 
             </div>
-
 
         </div>
 

--- a/frontend/poletto_skins/src/components/TopFilter/styles.scss
+++ b/frontend/poletto_skins/src/components/TopFilter/styles.scss
@@ -1,26 +1,15 @@
 .filter-top-container {
     display: flex;
-    flex-direction: row;
-    height: 34px;
+    height: 38px;
     padding-right: 21px;
+    gap: 15px;
     justify-content: space-between;
 
-    .left-container {
+    .filter-top-section {
         display: flex;
         flex-direction: row;
         gap: 15px;
-        width: 30%;
-        min-width: 500px;
-        height: 100%;
-
-        input {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            width: 100%;
-            padding: 6px;
-            border-radius: 0.25rem;
-            font-size: 14px;
-        }
+        min-width: 'min-content';
     }
+
 }

--- a/frontend/poletto_skins/src/contexts/CartContext.tsx
+++ b/frontend/poletto_skins/src/contexts/CartContext.tsx
@@ -1,0 +1,66 @@
+import { ItemType } from '@/types/entities/item'
+import { createContext, ReactNode, useState } from 'react'
+
+type CartContextValue = {
+    cart: ItemType[]
+    isItemInCart: (itemId: ItemType['id']) => boolean
+    addToCart: (item: ItemType) => void
+    removeFromCart: (itemId: ItemType['id']) => void
+    clearCart: () => void
+    totalItems: number
+    totalPrice: number
+}
+
+export const CartContext = createContext<CartContextValue>({
+    cart: [],
+    isItemInCart: () => { throw new Error('isItemInCart function not implemented') },
+    addToCart: () => { throw new Error('addToCart function not implemented') },
+    removeFromCart: () => { throw new Error('removeFromCart function not implemented') },
+    clearCart: () => { throw new Error('clearCart function not implemented') },
+    totalItems: 0,
+    totalPrice: 0,
+})
+
+type CartProviderProps = {
+    children: ReactNode
+}
+
+export const CartProvider = ({ children }: CartProviderProps) => {
+
+    const [cart, setCart] = useState<ItemType[]>([])
+
+    const isItemInCart = (itemId: ItemType['id']) => {
+        return cart.some((item) => item.id === itemId)
+    }
+
+    const addToCart = (item: ItemType) => {
+        if (!isItemInCart(item.id)) {
+            setCart([...cart, item])
+        }
+    }
+
+    const removeFromCart = (itemId: ItemType['id']) => {
+        setCart(cart.filter((item) => item.id !== itemId))
+    }
+
+    const clearCart = () => setCart([])
+
+    const totalItems = cart.length
+    const totalPrice = cart.reduce((acc, item) => acc + item.price, 0)
+
+    return (
+        <CartContext.Provider
+            value={{
+                cart,
+                isItemInCart,
+                addToCart,
+                removeFromCart,
+                clearCart,
+                totalItems,
+                totalPrice,
+            }}
+        >
+            {children}
+        </CartContext.Provider>
+    )
+}

--- a/frontend/poletto_skins/src/hooks/useCart.ts
+++ b/frontend/poletto_skins/src/hooks/useCart.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react'
+import { CartContext } from '../contexts/CartContext'
+
+export const useCart = () => useContext(CartContext)

--- a/frontend/poletto_skins/src/pages/Buy/index.tsx
+++ b/frontend/poletto_skins/src/pages/Buy/index.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from 'react'
 import TopFilter from '../..//components/TopFilter'
 import Catalog from '../../components/Catalog'
 import MainFilter from '../../components/MainFilter'
+import { useCart } from '../../hooks/useCart'
 
 //MOCKS
 const fetchedStickersFromApi: Sticker[] = [
@@ -264,6 +265,16 @@ type FilterData = {
 
 const Buy = () => {
 
+    const { addToCart, removeFromCart, isItemInCart } = useCart()
+
+    const handleAddCartButtonClick = (item: ItemType) => {
+        if (isItemInCart(item.id)) {
+            removeFromCart(item.id)
+        } else {
+            addToCart(item)
+        }
+    }
+
     const [items, setItems] = useState<ItemType[]>([])
 
     const [filterData, setFilterData] = useState<FilterData>()
@@ -311,7 +322,7 @@ const Buy = () => {
                 </div>
 
                 <div className='catalog-container'>
-                    <Catalog items={items} />
+                    <Catalog items={items} itemAction={handleAddCartButtonClick} />
                 </div>
 
             </div>

--- a/frontend/poletto_skins/src/pages/Buy/styles.scss
+++ b/frontend/poletto_skins/src/pages/Buy/styles.scss
@@ -13,7 +13,7 @@
     .buy-main-area {
         display: flex;
         flex-direction: column;
-        gap: 10px;
+        gap: 15px;
         height: 100%;
         width: 100%;
 


### PR DESCRIPTION
Esse pull request integra as alterações feitas na branch item-modal que incluem mas não se limitam a:

* Criado lógica do carrinho no frontend, através de um Context que por enquanto encapsula somente a rota /Buy e pode ser utilizada através de um hook useCart() abfa56e

* Criado componente do Carrinho, que exibe os itens adicionados, a opção de finalizar compra, opção de remover os itens e etc 5132e7b
![image](https://github.com/crysisprophet1234/poletto-skins/assets/117860590/d331264f-d1a5-4c46-997a-32ecde716f2e)
![image](https://github.com/crysisprophet1234/poletto-skins/assets/117860590/ae4f047c-f5a4-4f75-95ef-ce1f43fabda7)

* AddCartButton agora é reativo baseado na prop isItemInCart, alterando comportamento e estilo.
![image](https://github.com/crysisprophet1234/poletto-skins/assets/117860590/69a7ab86-e94b-4685-8b70-f7e331590054)

* Alterado TopFilter, adicionando o componente Cart na fim do componente e passando o Select para esquerda, entre o QuerySearch e FavoriteButton.
![image](https://github.com/crysisprophet1234/poletto-skins/assets/117860590/4c9159ac-c7a9-497b-b0f1-1fd6241d6873)