### PR TITLE
Creating initial checkout

### DIFF
--- a/frontend/poletto_skins/src/components/BuyModal/index.tsx
+++ b/frontend/poletto_skins/src/components/BuyModal/index.tsx
@@ -94,7 +94,7 @@ const BuyModal = ({ open, handleClose }: BuyModalProps) => {
                                 component='span'
                                 sx={{ color: '#806cf5' }}
                             >
-                                R${totalPrice}
+                                R${totalPrice.toFixed(2)}
                             </Box>
                         </Typography>
                         <Typography variant='h6'>

--- a/frontend/poletto_skins/src/components/BuyModal/index.tsx
+++ b/frontend/poletto_skins/src/components/BuyModal/index.tsx
@@ -2,16 +2,16 @@ import { Close } from '@mui/icons-material'
 import { Box, Button, IconButton, Modal, Stack, Typography } from '@mui/material'
 import { useCart } from '../../hooks/useCart'
 
-type ItemModalProps = {
+type BuyModalProps = {
     open: boolean
     handleClose: () => void
 }
 
-const BuyModal = ({ open, handleClose }: ItemModalProps) => {
+const BuyModal = ({ open, handleClose }: BuyModalProps) => {
 
     const userBalanceMock = 12700.38
 
-    const { cart, totalItems, totalPrice } = useCart()
+    const { totalItems, totalPrice } = useCart()
 
     return (
 
@@ -74,28 +74,6 @@ const BuyModal = ({ open, handleClose }: ItemModalProps) => {
                         </IconButton>
 
                     </Box>
-
-                    {/* 
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            color: '#BCBCC2'
-                        }}
-                    >
-                        <Typography
-                            variant='body1'
-                        >
-                            Itens no carrinho: {totalItems}
-                        </Typography>
-
-                        <Typography
-                            variant='body1'
-                        >
-                            Valor total: R${totalPrice}
-                        </Typography>
-                    </Box>
-                    */}
 
                     <Box
                         sx={{

--- a/frontend/poletto_skins/src/components/BuyModal/index.tsx
+++ b/frontend/poletto_skins/src/components/BuyModal/index.tsx
@@ -1,0 +1,183 @@
+import { Close } from '@mui/icons-material'
+import { Box, Button, IconButton, Modal, Stack, Typography } from '@mui/material'
+import { useCart } from '../../hooks/useCart'
+
+type ItemModalProps = {
+    open: boolean
+    handleClose: () => void
+}
+
+const BuyModal = ({ open, handleClose }: ItemModalProps) => {
+
+    const userBalanceMock = 12700.38
+
+    const { cart, totalItems, totalPrice } = useCart()
+
+    return (
+
+        <Modal
+            open={open}
+            onClose={handleClose}
+            aria-labelledby='buy-modal'
+            aria-describedby='buy-modal'
+        >
+            <Box sx={{
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                bgcolor: '#282633',
+                borderRadius: '.5rem',
+                boxShadow: 24,
+                p: 4,
+                outline: 0
+            }}>
+
+                <Stack
+                    direction='column'
+                    gap={1}
+                >
+
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexDirection: 'row',
+                            justifyContent: 'space-between',
+                            alignItems: 'center'
+                        }}
+                    >
+
+                        <Box>
+                            <Typography
+                                variant='h5'
+                            >
+                                Checkout
+                            </Typography>
+                        </Box>
+
+                        <IconButton
+                            onClick={handleClose}
+                            sx={{
+                                pt: 0,
+                                pr: 0
+                            }}
+                        >
+                            <Close
+                                fontSize='large'
+                                sx={{
+                                    fill: '#817e8f',
+                                    '&:hover': {
+                                        fill: '#bbb9c7'
+                                    }
+                                }}
+                            />
+                        </IconButton>
+
+                    </Box>
+
+                    {/* 
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            color: '#BCBCC2'
+                        }}
+                    >
+                        <Typography
+                            variant='body1'
+                        >
+                            Itens no carrinho: {totalItems}
+                        </Typography>
+
+                        <Typography
+                            variant='body1'
+                        >
+                            Valor total: R${totalPrice}
+                        </Typography>
+                    </Box>
+                    */}
+
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                        }}
+                    >
+                        <Typography variant='h6'>
+                            Você possui {' '}
+                            <Box
+                                component='span'
+                                sx={{ color: '#806cf5' }}
+                            >
+                                {totalItems}
+                            </Box>{' '}
+                            {totalItems === 1 ? 'item' : 'itens'} no carrinho, somando o valor de{' '}
+                            <Box
+                                component='span'
+                                sx={{ color: '#806cf5' }}
+                            >
+                                R${totalPrice}
+                            </Box>
+                        </Typography>
+                        <Typography variant='h6'>
+                            Seu saldo após essa compra será de {' '}
+                            <Box
+                                component='span'
+                                sx={{ color: '#806cf5' }}
+                            >
+                                R${(userBalanceMock - totalPrice).toFixed(2)}
+                            </Box>
+                        </Typography>
+
+                    </Box>
+
+                    <Typography variant='h6' fontWeight={'600'} textAlign={'center'}>
+                        Confirmar compra?
+                    </Typography>
+
+                </Stack>
+
+                <Box sx={{
+                    marginTop: 1,
+                    display: 'flex',
+                    flexDirection: 'row',
+                    gap: '15px'
+                }}>
+                    <Button
+                        onClick={handleClose}
+                        sx={{
+                            color: '#FFF',
+                            fontWeight: 'bold',
+                            backgroundColor: '#f05f75',
+                            width: 'calc(100% - 16px)',
+                            '&:hover': {
+                                backgroundColor: '#ff8095'
+                            }
+                        }}
+                    >
+                        RETORNAR
+                    </Button>
+                    <Button
+                        onClick={() => alert('checkout not implemented yet')}
+                        sx={{
+                            color: '#FFF',
+                            fontWeight: 'bold',
+                            backgroundColor: '#806cf5',
+                            width: 'calc(100% - 16px)',
+                            '&:hover': {
+                                backgroundColor: '#9F8FFF'
+                            }
+                        }}
+                    >
+                        CONFIRMAR
+                    </Button>
+                </Box>
+
+            </Box >
+        </Modal >
+
+    )
+
+}
+
+export default BuyModal

--- a/frontend/poletto_skins/src/components/Cart/ItemCartPopup/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/ItemCartPopup/index.tsx
@@ -5,11 +5,14 @@ import ItemCartMiniature from './ItemCartMiniature'
 
 type ItemCartPopupProps = {
     onClose: () => void
+    onCheckout: () => void
 }
 
-const ItemCartPopup = ({ onClose }: ItemCartPopupProps) => {
+const ItemCartPopup = ({ onClose, onCheckout }: ItemCartPopupProps) => {
 
-    const { cart, totalItems } = useCart()
+    const { cart, totalItems, totalPrice } = useCart()
+
+    const userBalanceMock = 12700.38
 
     return (
         <Paper
@@ -138,7 +141,12 @@ const ItemCartPopup = ({ onClose }: ItemCartPopupProps) => {
                         onClick={
                             totalItems == 0
                                 ? () => onClose()
-                                : () => alert('not implemented yet')
+                                : () => {
+                                    onClose()
+                                    totalPrice > userBalanceMock
+                                        ? alert('add funds not implemented yet')
+                                        : onCheckout()
+                                }
                         }
                         sx={{
                             color: '#FFF',
@@ -151,9 +159,9 @@ const ItemCartPopup = ({ onClose }: ItemCartPopupProps) => {
                         }}
                     >
                         {
-                            totalItems > 0
-                                ? 'Finalizar compra'
-                                : 'Ir para o Mercado'
+                            totalItems == 0
+                                ? 'Ir para o Mercado'
+                                : 'Finalizar compra'
                         }
                     </Button>
                 </Box>

--- a/frontend/poletto_skins/src/components/Cart/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/index.tsx
@@ -1,20 +1,24 @@
 import { Box, ClickAwayListener, Popper } from '@mui/material'
 import { useState } from 'react'
+import BuyModal from '../BuyModal'
 import ItemCartPopup from './ItemCartPopup'
 import ShowCartButton from './ShowCartButton'
 
 const Cart = () => {
 
     const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
-    const [open, setOpen] = useState(false)
+
+    const [isCartOpen, setIsCartOpen] = useState(false)
+
+    const [isBuyModalOpen, setIsBuyModalOpen] = useState(false)
 
     const handleOutsideClick = () => {
-        setOpen(false)
+        setIsCartOpen(false)
     }
 
-    const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const handleShowCartClick = (event: React.MouseEvent<HTMLButtonElement>) => {
         setAnchorEl(event.currentTarget)
-        setOpen(!open)
+        setIsCartOpen(!isCartOpen)
     }
 
     return (
@@ -23,16 +27,21 @@ const Cart = () => {
 
             <Box>
 
-                <ShowCartButton handleClick={handleClick} />
+                <ShowCartButton handleClick={handleShowCartClick} />
 
                 <Popper
                     id='cart-popper'
                     placement='bottom-end'
-                    open={open}
+                    open={isCartOpen}
                     anchorEl={anchorEl}
                 >
-                    <ItemCartPopup onClose={() => setOpen(false)} />
+                    <ItemCartPopup onClose={() => setIsCartOpen(false)} onCheckout={() => setIsBuyModalOpen(!isBuyModalOpen)} />
                 </Popper>
+
+                <BuyModal
+                    open={isBuyModalOpen}
+                    handleClose={() => setIsBuyModalOpen(!isBuyModalOpen)}
+                />
 
             </Box>
 


### PR DESCRIPTION
Ao clicar em "confirmar compra" no popper aberto pelo botão do carrinho, será fechado o popper e mostrado na tela o BuyModal que é responsável por mostrar:
* Valor total da compra
* Quantos itens temos no carrinho
* Quanto de saldo teremos após a compra caso seja confirmado
* Opção de retornar, onde o modal é fechado mas os itens continuam no carrinho
* Opção de confirmar, efetivando a venda, por enquanto é não implementado.
Para que o modal apareça ao clicar no "confirmar compra" é necessário que o usuário tenha saldo suficiente para a compra, caso contrário será levado para a tela de adição de saldo, que por enquanto sequer existe.

![image](https://github.com/user-attachments/assets/99df0107-b3f7-48d7-863f-633d70f04aac)
