### PR TITLE
Fixing aliased imports

### DIFF
--- a/frontend/poletto_skins/src/components/BuyModal/index.tsx
+++ b/frontend/poletto_skins/src/components/BuyModal/index.tsx
@@ -1,6 +1,6 @@
+import { useCart } from '@/hooks/useCart'
 import { Close } from '@mui/icons-material'
 import { Box, Button, IconButton, Modal, Stack, Typography } from '@mui/material'
-import { useCart } from '../../hooks/useCart'
 
 type BuyModalProps = {
     open: boolean

--- a/frontend/poletto_skins/src/components/Cart/ItemCartPopup/ItemCartMiniature/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/ItemCartPopup/ItemCartMiniature/index.tsx
@@ -1,7 +1,7 @@
+import AddCartButton from '@/components/AddCartButton'
+import { useCart } from '@/hooks/useCart'
 import { ItemType } from '@/types/entities/item'
 import { Box, Paper, Stack, Tooltip, Typography } from '@mui/material'
-import { useCart } from '../../../../hooks/useCart'
-import AddCartButton from '../../../AddCartButton'
 
 type ItemCartMiniatureProps = {
     item: ItemType

--- a/frontend/poletto_skins/src/components/Cart/ItemCartPopup/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/ItemCartPopup/index.tsx
@@ -1,7 +1,8 @@
+import ItemCartMiniature from '@/components/Cart/ItemCartPopup/ItemCartMiniature'
+import { useCart } from '@/hooks/useCart'
 import { AddShoppingCartRounded, Close } from '@mui/icons-material'
 import { Box, Button, Grid, IconButton, Paper, Stack, Typography } from '@mui/material'
-import { useCart } from '../../../hooks/useCart'
-import ItemCartMiniature from './ItemCartMiniature'
+
 
 type ItemCartPopupProps = {
     onClose: () => void

--- a/frontend/poletto_skins/src/components/Cart/ShowCartButton/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/ShowCartButton/index.tsx
@@ -1,6 +1,6 @@
+import { useCart } from '@/hooks/useCart'
 import { ShoppingCart } from '@mui/icons-material'
 import { Badge, Button, Typography } from '@mui/material'
-import { useCart } from '../../../hooks/useCart'
 
 type ShowCartButtonProps = {
     handleClick: (e: React.MouseEvent<HTMLButtonElement>) => void

--- a/frontend/poletto_skins/src/components/Cart/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/index.tsx
@@ -1,8 +1,8 @@
+import BuyModal from '@/components/BuyModal'
+import ItemCartPopup from '@/components/Cart/ItemCartPopup'
+import ShowCartButton from '@/components/Cart/ShowCartButton'
 import { Box, ClickAwayListener, Popper } from '@mui/material'
 import { useState } from 'react'
-import BuyModal from '../BuyModal'
-import ItemCartPopup from './ItemCartPopup'
-import ShowCartButton from './ShowCartButton'
 
 const Cart = () => {
 

--- a/frontend/poletto_skins/src/components/Catalog/index.tsx
+++ b/frontend/poletto_skins/src/components/Catalog/index.tsx
@@ -1,10 +1,11 @@
 import './styles.scss'
 
+import ItemCard from '@/components/ItemCard'
+import ItemModal from '@/components/ItemModal'
 import { ItemType } from '@/types/entities/item'
 import { Box, Grid, Skeleton } from '@mui/material'
 import { useEffect, useState } from 'react'
-import ItemCard from '../ItemCard'
-import ItemModal from '../ItemModal'
+
 
 type CatalogProps = {
     items: ItemType[]

--- a/frontend/poletto_skins/src/components/ItemCard/index.tsx
+++ b/frontend/poletto_skins/src/components/ItemCard/index.tsx
@@ -1,11 +1,10 @@
-import './styles.scss'
-
+import AddCartButton from '@/components/AddCartButton'
+import { useCart } from '@/hooks/useCart'
 import { ItemType } from '@/types/entities/item'
 import { useEffect, useState } from 'react'
 import { FaSteam } from 'react-icons/fa6'
 import { MdFavorite } from 'react-icons/md'
-import { useCart } from '../../hooks/useCart'
-import AddCartButton from '../AddCartButton'
+import './styles.scss'
 
 type ItemCardProps = {
     itemProps: ItemType

--- a/frontend/poletto_skins/src/components/ItemModal/index.tsx
+++ b/frontend/poletto_skins/src/components/ItemModal/index.tsx
@@ -1,15 +1,14 @@
-import { Close } from '@mui/icons-material'
-import './styles.scss'
-
+import AddCartButton from '@/components/AddCartButton'
+import FloatBar from '@/components/FloatBar'
+import { useCart } from '@/hooks/useCart'
 import { ItemType } from '@/types/entities/item'
+import { Close } from '@mui/icons-material'
 import { Divider, Link, Stack, Tooltip } from '@mui/material'
 import Box from '@mui/material/Box'
 import Modal from '@mui/material/Modal'
 import Typography from '@mui/material/Typography'
 import { FaExternalLinkAlt } from 'react-icons/fa'
-import { useCart } from '../../hooks/useCart'
-import AddCartButton from '../AddCartButton'
-import FloatBar from '../FloatBar'
+import './styles.scss'
 
 type ItemModalProps = {
     item: ItemType

--- a/frontend/poletto_skins/src/components/MainFilter/index.tsx
+++ b/frontend/poletto_skins/src/components/MainFilter/index.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useRef, useState } from 'react'
-import './styles.scss'
-
-import Slider from '@mui/material/Slider'
-
+import FormInputText from '@/components/FormComponents/FormInputText'
+import FormSingleCheckbox from '@/components/FormComponents/FormMultiCheckBox'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Category } from '@mui/icons-material'
 import { Box, Checkbox, FormControlLabel, Typography, debounce } from '@mui/material'
+import Slider from '@mui/material/Slider'
+import { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { FaChevronUp } from 'react-icons/fa'
 import { GrPowerReset } from 'react-icons/gr'
 import { z } from 'zod'
-import FormInputText from '../FormComponents/FormInputText'
-import FormSingleCheckbox from '../FormComponents/FormMultiCheckBox'
+import './styles.scss'
 
 type FilterSections = 'price' | 'float' | 'category' | 'others'
 

--- a/frontend/poletto_skins/src/components/Navbar/LoginButton/index.tsx
+++ b/frontend/poletto_skins/src/components/Navbar/LoginButton/index.tsx
@@ -1,6 +1,6 @@
+import { useAuth } from '@/hooks/useAuth'
 import { Box, Button, Typography } from '@mui/material'
 import { FaSteam } from 'react-icons/fa'
-import { useAuth } from '../../../hooks/useAuth'
 
 const LoginButton = () => {
 

--- a/frontend/poletto_skins/src/components/Navbar/NotificationMenu/index.tsx
+++ b/frontend/poletto_skins/src/components/Navbar/NotificationMenu/index.tsx
@@ -1,9 +1,9 @@
+import NavbarButton from '@/components/Navbar/NavbarButton'
 import { Notification } from '@/types/entities/notification'
 import { Close } from '@mui/icons-material'
 import { Badge, Box, ClickAwayListener, Divider, IconButton, Paper, Popper, Stack, Typography } from '@mui/material'
 import React, { useState } from 'react'
 import { IoNotificationsSharp } from 'react-icons/io5'
-import NavbarButton from '../NavbarButton'
 
 const NotificationMenu = () => {
 

--- a/frontend/poletto_skins/src/components/Navbar/ProfileMenu/index.tsx
+++ b/frontend/poletto_skins/src/components/Navbar/ProfileMenu/index.tsx
@@ -1,7 +1,7 @@
+import { useAuth } from '@/hooks/useAuth'
 import { Edit, ExitToApp, Help, HistoryRounded, Sell } from '@mui/icons-material'
 import { Avatar, Box, ClickAwayListener, IconButton, ListItemIcon, MenuItem, Paper, Popper } from '@mui/material'
 import { useState } from 'react'
-import { useAuth } from '../../../hooks/useAuth'
 
 const ProfileMenu = () => {
 

--- a/frontend/poletto_skins/src/components/Navbar/index.tsx
+++ b/frontend/poletto_skins/src/components/Navbar/index.tsx
@@ -1,18 +1,13 @@
-import { Link } from 'react-router-dom'
-
-import LogoUrl from '../../assets/images/polettoskins-logo.png'
-
-
+import LogoUrl from '@/assets/images/polettoskins-logo.png'
+import BalanceButton from '@/components/Navbar/BalanceButton'
+import LoginButton from '@/components/Navbar/LoginButton'
+import NavbarButton from '@/components/Navbar/NavbarButton'
+import NotificationMenu from '@/components/Navbar/NotificationMenu'
+import ProfileMenu from '@/components/Navbar/ProfileMenu'
+import { useAuth } from '@/hooks/useAuth'
 import { FavoriteBorder } from '@mui/icons-material'
 import { Box, Stack } from '@mui/material'
-import { useAuth } from '../../hooks/useAuth'
-import BalanceButton from './BalanceButton'
-import LoginButton from './LoginButton'
-import NavbarButton from './NavbarButton'
-import NotificationMenu from './NotificationMenu'
-import ProfileMenu from './ProfileMenu'
-
-
+import { Link } from 'react-router-dom'
 
 const Navbar = () => {
 

--- a/frontend/poletto_skins/src/components/TopFilter/index.tsx
+++ b/frontend/poletto_skins/src/components/TopFilter/index.tsx
@@ -1,14 +1,14 @@
+import Cart from '@/components/Cart'
+import FormSearchQueryText from '@/components/FormComponents/FormQuerySearchText'
+import FormSelect from '@/components/FormComponents/FormSelect'
+import FormToggleButton from '@/components/FormComponents/FormToggleButton'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { DiscountRounded, NewReleasesRounded, SortRounded } from '@mui/icons-material'
 import { debounce } from '@mui/material'
 import { useEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
-import Cart from '../Cart'
-import FormSearchQueryText from '../FormComponents/FormQuerySearchText'
-import FormToggleButton from '../FormComponents/FormToggleButton'
 import './styles.scss'
-import FormSelect from '../FormComponents/FormSelect'
 
 const sortOptions = [
     {

--- a/frontend/poletto_skins/src/contexts/AuthContex.tsx
+++ b/frontend/poletto_skins/src/contexts/AuthContex.tsx
@@ -1,9 +1,9 @@
 
+import { get } from '@/services/api'
+import { steamAuth } from '@/services/auth'
 import { SteamUser } from '@/types/vendor/steamUser'
 import { createContext, ReactNode, useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { get } from '../services/api'
-import { steamAuth } from '../services/auth'
 
 type AuthContextType = {
     isAuthenticated: boolean

--- a/frontend/poletto_skins/src/hooks/useAuth.ts
+++ b/frontend/poletto_skins/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
+import { AuthContext } from '@/contexts/AuthContex'
 import { useContext } from 'react'
-import { AuthContext } from '../contexts/AuthContex'
 
 
 export const useAuth = () => useContext(AuthContext)

--- a/frontend/poletto_skins/src/hooks/useCart.ts
+++ b/frontend/poletto_skins/src/hooks/useCart.ts
@@ -1,4 +1,4 @@
+import { CartContext } from '@/contexts/CartContext'
 import { useContext } from 'react'
-import { CartContext } from '../contexts/CartContext'
 
 export const useCart = () => useContext(CartContext)

--- a/frontend/poletto_skins/src/pages/Buy/index.tsx
+++ b/frontend/poletto_skins/src/pages/Buy/index.tsx
@@ -1,12 +1,11 @@
-import './styles.scss'
-
+import Catalog from '@/components/Catalog'
+import MainFilter from '@/components/MainFilter'
+import TopFilter from '@/components/TopFilter'
+import { useCart } from '@/hooks/useCart'
 import { GloveSkin, ItemType, Sticker, WeaponSkin } from '@/types/entities/item'
 import axios from 'axios'
 import { useCallback, useEffect, useState } from 'react'
-import TopFilter from '../..//components/TopFilter'
-import Catalog from '../../components/Catalog'
-import MainFilter from '../../components/MainFilter'
-import { useCart } from '../../hooks/useCart'
+import './styles.scss'
 
 //MOCKS
 const fetchedStickersFromApi: Sticker[] = [

--- a/frontend/poletto_skins/src/pages/Home/index.tsx
+++ b/frontend/poletto_skins/src/pages/Home/index.tsx
@@ -1,7 +1,6 @@
-import './styles.scss'
-
+import SideNavbar from '@/components/SideNavbar'
 import { Outlet } from 'react-router-dom'
-import SideNavbar from '../../components/SideNavbar'
+import './styles.scss'
 
 const Home = () => {
 

--- a/frontend/poletto_skins/src/pages/Login/index.tsx
+++ b/frontend/poletto_skins/src/pages/Login/index.tsx
@@ -1,7 +1,6 @@
+import { useAuth } from '@/hooks/useAuth'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { useAuth } from '../../hooks/useAuth'
-
 
 const Login = () => {
 

--- a/frontend/poletto_skins/src/routes/root.tsx
+++ b/frontend/poletto_skins/src/routes/root.tsx
@@ -1,5 +1,5 @@
-import Navbar from '../components/Navbar'
-import Home from '../pages/Home'
+import Navbar from '@/components/Navbar'
+import Home from '@/pages/Home'
 
 const Root = () => {
 

--- a/frontend/poletto_skins/vite.config.ts
+++ b/frontend/poletto_skins/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './ src'),
+      '@': path.resolve(__dirname, './src'),
     }
   }
 })


### PR DESCRIPTION
Corrigindo importações usando o alias @, isso agora é possível pois foi corrigido o erro no vite.config.ts (havia um espaço em branco em ./ src)

resolve: {
    alias: {
      '@': path.resolve(__dirname, **'./ src'**),
    }
  }