### PR TITLE
Adapting client to receive api items

### DIFF
--- a/backend/poletto_skins/src/main/java/com/poletto/polettoskins/entities/SteamItem.java
+++ b/backend/poletto_skins/src/main/java/com/poletto/polettoskins/entities/SteamItem.java
@@ -16,7 +16,7 @@ public class SteamItem implements Serializable {
 	private String assetId;
 	private String ownerSteamId;
 	private String d;
-	private String m;
+	private String marketId;
 	private Integer origin;
     private Integer quality;
     private Integer rarity;
@@ -45,8 +45,8 @@ public class SteamItem implements Serializable {
 	public SteamItem(
 		String assetId,
 		String ownerSteamId,
-		String d,
-		String m,
+		String marketId,
+		String d,		
 		Integer origin,
 		Integer quality,
 		Integer rarity,	
@@ -72,7 +72,7 @@ public class SteamItem implements Serializable {
 	) {
 		this.assetId = assetId;
 		this.ownerSteamId = ownerSteamId;
-		this.m = m;
+		this.marketId = marketId;
 		this.d = d;
 		this.origin = origin;
 		this.quality = quality;
@@ -114,12 +114,12 @@ public class SteamItem implements Serializable {
 		this.ownerSteamId = ownerSteamId;
 	}
 
-	public String getM() {
-		return m;
+	public String getMarketId() {
+		return marketId;
 	}
 
-	public void setM(String m) {
-		this.m = m;
+	public void setMarketId(String marketId) {
+		this.marketId = marketId;
 	}
 	
 
@@ -309,7 +309,7 @@ public class SteamItem implements Serializable {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(assetId, d, m, ownerSteamId);
+		return Objects.hash(assetId, d, marketId, ownerSteamId);
 	}
 
 	@Override
@@ -321,13 +321,13 @@ public class SteamItem implements Serializable {
 		if (getClass() != obj.getClass())
 			return false;
 		SteamItem other = (SteamItem) obj;
-		return Objects.equals(assetId, other.assetId) && Objects.equals(d, other.d) && Objects.equals(m, other.m)
+		return Objects.equals(assetId, other.assetId) && Objects.equals(d, other.d) && Objects.equals(marketId, other.marketId)
 				&& Objects.equals(ownerSteamId, other.ownerSteamId);
 	}
 
 	@Override
 	public String toString() {
-		return "SteamItem [a=" + assetId + ", s=" + ownerSteamId + ", d=" + d + ", m=" + m + ", origin=" + origin + ", quality="
+		return "SteamItem [a=" + assetId + ", s=" + ownerSteamId + ", d=" + d + ", marketId=" + marketId + ", origin=" + origin + ", quality="
 				+ quality + ", rarity=" + rarity + ", paintSeed=" + paintSeed + ", defIndex=" + defIndex
 				+ ", paintIndex=" + paintIndex + ", floatId=" + floatId + ", lowRank=" + lowRank + ", highRank="
 				+ highRank + ", floatValue=" + floatValue + ", imageUrl=" + imageUrl + ", inspectUrl=" + inspectUrl

--- a/backend/poletto_skins/src/main/java/com/poletto/polettoskins/entities/SteamSticker.java
+++ b/backend/poletto_skins/src/main/java/com/poletto/polettoskins/entities/SteamSticker.java
@@ -14,6 +14,7 @@ public class SteamSticker implements Serializable {
 	@Id
 	private Integer stickerId;
 	private Integer slot;
+	private String imageUrl;
     private Double wear;
     private Double scale;
     private Integer rotation;
@@ -26,6 +27,7 @@ public class SteamSticker implements Serializable {
 	public SteamSticker(
 		Integer stickerId,
 		Integer slot,
+		String imageUrl,
 		Double wear,
 		Double scale,
 		Integer rotation,
@@ -35,7 +37,8 @@ public class SteamSticker implements Serializable {
 	) {
 		this.stickerId = stickerId;
 		this.slot = slot;
-		this.wear = wear;
+		this.imageUrl = imageUrl;
+		this.wear = wear;	
 		this.scale = scale;
 		this.rotation = rotation;
 		this.codename = codename;
@@ -57,6 +60,14 @@ public class SteamSticker implements Serializable {
 
 	public void setSlot(Integer slot) {
 		this.slot = slot;
+	}
+
+	public String getImageUrl() {
+		return imageUrl;
+	}
+
+	public void setImageUrl(String imageUrl) {
+		this.imageUrl = imageUrl;
 	}
 
 	public Double getWear() {
@@ -126,9 +137,9 @@ public class SteamSticker implements Serializable {
 
 	@Override
 	public String toString() {
-		return "SteamSticker [stickerId=" + stickerId + ", slot=" + slot + ", wear=" + wear + ", scale=" + scale
-				+ ", rotation=" + rotation + ", codename=" + codename + ", material=" + material + ", name=" + name
-				+ "]";
+		return "SteamSticker [stickerId=" + stickerId + ", slot=" + slot + ", imageUrl=" + imageUrl + ", wear=" + wear
+				+ ", scale=" + scale + ", rotation=" + rotation + ", codename=" + codename + ", material=" + material
+				+ ", name=" + name + "]";
 	}
 
 }

--- a/frontend/poletto_skins/src/App.tsx
+++ b/frontend/poletto_skins/src/App.tsx
@@ -46,7 +46,9 @@ const router = createBrowserRouter(
           path: '/sell',
           element:
             <Suspense fallback={<h1>Loading...</h1>}>
-              <Sell />
+              <CartProvider>
+                <Sell />
+              </CartProvider>
             </Suspense>
         }
       ]

--- a/frontend/poletto_skins/src/components/Cart/ItemCartPopup/ItemCartMiniature/index.tsx
+++ b/frontend/poletto_skins/src/components/Cart/ItemCartPopup/ItemCartMiniature/index.tsx
@@ -1,10 +1,12 @@
 import AddCartButton from '@/components/AddCartButton'
 import { useCart } from '@/hooks/useCart'
-import { ItemType } from '@/types/entities/item'
+import { MarketItem } from '@/types/entities/steam-item'
+import { extractStickerFinish } from '@/utils/extractStickerFinish'
+import { itemWearAbbreviator, WearName } from '@/utils/itemWearAbbreviator'
 import { Box, Paper, Stack, Tooltip, Typography } from '@mui/material'
 
 type ItemCartMiniatureProps = {
-    item: ItemType
+    item: MarketItem
 }
 
 const ItemCartMiniature = ({ item }: ItemCartMiniatureProps) => {
@@ -42,7 +44,7 @@ const ItemCartMiniature = ({ item }: ItemCartMiniatureProps) => {
                 >
                     <img
                         src={`${item.imageUrl}/${imageDimensions.width}fx${imageDimensions.height}f`}
-                        alt={item.name}
+                        alt={item.itemName}
                         loading='lazy'
                         style={{
                             width: '100%',
@@ -60,47 +62,53 @@ const ItemCartMiniature = ({ item }: ItemCartMiniatureProps) => {
                         arrow
                         title={
                             <Typography>
-                                {`${'subCategory' in item ? item.subCategory : item.category} | ${item.name}`}
+                                {item.fullItemName}
                             </Typography>
                         }
                     >
                         <Typography noWrap fontSize={'14px'}>
-                            {`${'subCategory' in item ? item.subCategory : ''} ${item.name}`}
+                            {item.weaponType.toLowerCase() == 'sticker'
+                                ? item.stickers[0].name
+                                : item.itemName
+                            }
                         </Typography>
                     </Tooltip>
 
-                    <Stack direction={'row'} justifyContent={'space-between'} fontSize={'14px'}>
+                    <Box>
 
-                        {'statTrak' in item &&
-                            <Typography color='#CF6A32' fontSize={'14px'}>
-                                ST
-                            </Typography>
-                        }
-
-                        {'floatShort' in item &&
+                        {item.weaponType.toLowerCase() == 'sticker'
+                            ?
                             <Typography fontSize={'14px'}>
-                                {item.floatShort}
+                                {extractStickerFinish(item.fullItemName)}
                             </Typography>
+                            :
+                            <Stack direction={'row'} justifyContent={'space-between'}>
+                                {item.quality == 9 &&
+                                    <Typography color='#CF6A32' fontSize={'14px'}>
+                                        ST
+                                    </Typography>
+                                }
+
+                                {item.wearName &&
+                                    <Typography fontSize={'14px'}>
+                                        {itemWearAbbreviator(item.wearName as WearName)}
+                                    </Typography>
+                                }
+
+                                {item.floatValue &&
+                                    <Typography fontSize={'14px'}>
+                                        {item.floatValue.toFixed(4)}
+                                    </Typography>
+                                }
+                            </Stack>
                         }
 
-                        {'floatFull' in item &&
-                            <Typography fontSize={'14px'}>
-                                {item.floatFull.toFixed(4)}
-                            </Typography>
-                        }
-
-                        {'finish' in item &&
-                            <Typography fontSize={'14px'}>
-                                {item.finish}
-                            </Typography>
-                        }
-
-                    </Stack>
+                    </Box>
 
                 </Box>
 
                 <Box height={'28px'}>
-                    <AddCartButton isItemInCart={true} onClick={() => removeFromCart(item.id)} />
+                    <AddCartButton isItemInCart={true} onClick={() => removeFromCart(item.assetId)} />
                 </Box>
 
             </Stack >

--- a/frontend/poletto_skins/src/components/Catalog/index.tsx
+++ b/frontend/poletto_skins/src/components/Catalog/index.tsx
@@ -1,15 +1,15 @@
 import './styles.scss'
 
 import ItemCard from '@/components/ItemCard'
-import ItemModal from '@/components/ItemModal'
-import { ItemType } from '@/types/entities/item'
-import { Box, Grid, Skeleton } from '@mui/material'
+import { MarketItem } from '@/types/entities/steam-item'
+import { Box, Button, Grid, Skeleton } from '@mui/material'
 import { useEffect, useState } from 'react'
+import ItemModal from '../ItemModal'
 
 
 type CatalogProps = {
-    items: ItemType[]
-    itemAction: (item: ItemType) => void
+    items: MarketItem[]
+    itemAction: (item: MarketItem) => void
 }
 
 const Catalog = ({ items, itemAction }: CatalogProps) => {
@@ -22,11 +22,11 @@ const Catalog = ({ items, itemAction }: CatalogProps) => {
         }
     }, [items])
 
-    const [selectedItem, setSelectedItem] = useState<ItemType>()
+    const [selectedItem, setSelectedItem] = useState<MarketItem>()
 
     const [open, setOpen] = useState(false)
 
-    const handleOpen = (item: ItemType) => {
+    const handleOpen = (item: MarketItem) => {
         setSelectedItem(item)
         setOpen(true)
     }
@@ -40,7 +40,14 @@ const Catalog = ({ items, itemAction }: CatalogProps) => {
 
         <div className='catalog-main-container'>
 
-            <Box sx={{ flexGrow: 1 }}>
+            <Box
+                sx={{
+                    flexGrow: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 2
+                }}
+            >
                 <Grid container justifyContent='space-between' spacing={1} columns={{ xs: 4, sm: 8, md: 12, lg: 12, xl: 16 }}>
                     {loading
                         ? Array.from(new Array(12)).map((_, index) => (
@@ -52,20 +59,36 @@ const Catalog = ({ items, itemAction }: CatalogProps) => {
                                 />
                             </Grid>
                         ))
-                        : items.map((item, index) => (
-                            <Grid item xs={2} sm={4} md={4} lg={3} key={index}>
+                        : items.map((item) => (
+                            <Grid item xs={2} sm={4} md={4} lg={3} key={item.assetId}>
                                 <ItemCard
                                     itemProps={item}
-                                    key={item.id}
+                                    key={item.assetId}
                                     itemAction={() => itemAction(item)}
                                     openModal={() => handleOpen(item)}
                                 />
                             </Grid>
                         ))}
                 </Grid>
+                <Button
+                    sx={{
+                        width: 'fit-content',
+                        alignSelf: 'center',
+                        color: '#FFF',
+                        backgroundColor: '#806cf5',
+                        borderRadius: '0.25rem',
+                        transition: 'background-color 0.3s ease-in-out',
+                        '&:hover': {
+                            backgroundColor: '#9F8FFF'
+                        }
+                    }}
+                >
+                    Carregar mais {/*TODO*/}
+                </Button>
             </Box>
 
-            {selectedItem &&
+            {
+                selectedItem &&
                 <ItemModal
                     open={open}
                     itemAction={() => itemAction(selectedItem)}

--- a/frontend/poletto_skins/src/components/ItemCard/index.tsx
+++ b/frontend/poletto_skins/src/components/ItemCard/index.tsx
@@ -1,13 +1,15 @@
 import AddCartButton from '@/components/AddCartButton'
 import { useCart } from '@/hooks/useCart'
-import { ItemType } from '@/types/entities/item'
+import { MarketItem } from '@/types/entities/steam-item'
+import { itemWearAbbreviator, WearName } from '@/utils/itemWearAbbreviator'
+import { Tooltip, Typography } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { FaSteam } from 'react-icons/fa6'
 import { MdFavorite } from 'react-icons/md'
 import './styles.scss'
 
 type ItemCardProps = {
-    itemProps: ItemType
+    itemProps: MarketItem
     openModal: () => void
     itemAction: () => void
 }
@@ -16,7 +18,7 @@ const ItemCard = ({ itemProps, openModal, itemAction }: ItemCardProps) => {
 
     const { isItemInCart } = useCart()
 
-    const [item, setItem] = useState<ItemType | null>(null)
+    const [item, setItem] = useState<MarketItem | null>(null)
 
     const [isHovered, setIsHovered] = useState(false)
 
@@ -39,39 +41,51 @@ const ItemCard = ({ itemProps, openModal, itemAction }: ItemCardProps) => {
 
             <div className='item-info-container'>
 
-                <span className='skin-name'>
-                    {'finish' in item ? `${item.name} (${item.finish})` : item.name}
-                </span>
+                {item.weaponType.toLowerCase() == 'sticker'
+                    ? (
+                        <>
+                            <span className='skin-name'>
+                                {item.stickers[0].name}
+                            </span>
 
-                {'category' in item && 'subCategory' in item ?
-                    <span className='category'>
-                        {`${item.category} | ${item.subCategory}`}
-                    </span>
-                    :
-                    <span className='category'>
-                        {`${item.category}`}
-                    </span>
+                            <span className='category'>
+                                {item.weaponType}
+                            </span>
+                        </>
+                    ) : (
+                        <>
+                            <span className='skin-name'>
+                                {item.itemName == '-' ? 'Vanilla' : item.itemName}
+                            </span>
+
+                            <span className='category'>
+                                {item.weaponType /*TODO: subcategory?*/}
+                            </span>
+
+                            <div className='additional-info'>
+
+                                {item.qualityName.toLowerCase().includes('stattrak') && (
+                                    <span className='stat-trak'>ST</span>
+                                )}
+
+                                <span className='float-short'>
+                                    {itemWearAbbreviator(item.wearName as WearName)}
+                                </span>
+
+                                <Tooltip title={
+                                    <Typography noWrap minWidth='fit-content'>
+                                        {item.floatValue}
+                                    </Typography>
+                                }>
+                                    <span className='float-full'>
+                                        {item.floatValue.toFixed(4)}
+                                    </span>
+                                </Tooltip>
+
+                            </div>
+                        </>
+                    )
                 }
-
-                <div className='additional-info'>
-
-                    {'statTrak' in item && item.statTrak == true && (
-                        <span className='stat-trak'>ST</span>
-                    )}
-
-                    {'floatShort' in item && (
-                        <span className='float-short'>
-                            {item?.floatShort}
-                        </span>
-                    )}
-
-                    {'floatFull' in item && (
-                        <span className='float-full'>
-                            {item?.floatFull}
-                        </span>
-                    )}
-
-                </div>
 
             </div>
 
@@ -81,13 +95,13 @@ const ItemCard = ({ itemProps, openModal, itemAction }: ItemCardProps) => {
                     <img src={item?.imageUrl} alt='skin-image' loading='lazy' />
                 </div>
 
-                {'stickerArray' in item && (
+                {item.weaponType.toLowerCase() !== 'sticker' && (
                     <div className='sticker-stack'>
 
-                        {item.stickerArray.map((sticker) => {
+                        {item.stickers.slice(0, 4).map((sticker, index) => { //TODO: slicing 4 stickers
                             return (
-                                <div className='sticker' key={sticker.id}>
-                                    <img src={sticker.imageUrl} alt='sticker' loading='lazy' />
+                                <div className='sticker' key={sticker.stickerId + '-' + index}>
+                                    <img src={sticker.imageUrl} alt={sticker.name} loading='lazy' />
                                 </div>
                             )
                         })}
@@ -103,17 +117,17 @@ const ItemCard = ({ itemProps, openModal, itemAction }: ItemCardProps) => {
 
                     {item?.discount && item.discount > 0 &&
                         <div className='discount'>
-                            <span>{`-${item.discount}%`}</span>
+                            <span>{`-${item.discount.toFixed(2)}%`}</span>
                         </div>
                     }
 
                     <div className='price'>
-                        <span>{`R$ ${item?.price}`}</span>
+                        <span>{`R$ ${item?.price.toFixed(2)}`}</span>
                     </div>
 
                     <div className='steam-price'>
                         <FaSteam />
-                        <span>{`R$ ${item?.steamPrice}`}</span>
+                        <span>{`R$ ${item?.steamPrice.toFixed(2)}`}</span>
                     </div>
 
                 </div>
@@ -128,7 +142,7 @@ const ItemCard = ({ itemProps, openModal, itemAction }: ItemCardProps) => {
 
                 <div className='add-cart-container' onClick={(e) => e.stopPropagation()}>
                     <AddCartButton
-                        isItemInCart={isItemInCart(item.id)}
+                        isItemInCart={isItemInCart(item.assetId)}
                         onClick={itemAction}
                         isHovered={isHovered}
                     />

--- a/frontend/poletto_skins/src/components/ItemModal/index.tsx
+++ b/frontend/poletto_skins/src/components/ItemModal/index.tsx
@@ -1,7 +1,7 @@
 import AddCartButton from '@/components/AddCartButton'
 import FloatBar from '@/components/FloatBar'
 import { useCart } from '@/hooks/useCart'
-import { ItemType } from '@/types/entities/item'
+import { MarketItem } from '@/types/entities/steam-item'
 import { Close } from '@mui/icons-material'
 import { Divider, Link, Stack, Tooltip } from '@mui/material'
 import Box from '@mui/material/Box'
@@ -11,7 +11,7 @@ import { FaExternalLinkAlt } from 'react-icons/fa'
 import './styles.scss'
 
 type ItemModalProps = {
-    item: ItemType
+    item: MarketItem
     open: boolean
     handleClose: () => void
     itemAction: () => void
@@ -20,21 +20,6 @@ type ItemModalProps = {
 const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
 
     const { isItemInCart } = useCart()
-
-    const fullFloatCategoryName = (floatShort: string) => {
-        switch (floatShort.toLocaleLowerCase()) {
-            case 'bs':
-                return 'Battle-Scared'
-            case 'ww':
-                return 'Well-Worn'
-            case 'ft':
-                return 'Field-Tested'
-            case 'mw':
-                return 'Minimal Wear'
-            case 'fn':
-                return 'Factory New'
-        }
-    }
 
     if (!item) return
 
@@ -64,36 +49,22 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
 
                         <div className='item-title'>
 
-                            {'statTrak' in item && item.statTrak &&
+                            {item.quality == 9 &&
                                 <Typography
                                     variant='h5'
                                     fontWeight={600}
-                                    color={'#CF6A32'}>
-                                    StatTrak™
-                                </Typography>
-                            }
-
-                            {'subCategory' in item && item.subCategory &&
-                                <Typography
-                                    variant='h5'
-                                    fontWeight={600}>
-                                    {item.subCategory} |
+                                    color={'#CF6A32'}
+                                >
+                                    {item.qualityName}&nbsp;
                                 </Typography>
                             }
 
                             <Typography
                                 variant='h5'
-                                fontWeight={600}>
-                                {item.name}
+                                fontWeight={600}
+                            >
+                                {`${item.fullItemName.replace('StatTrak™', '')} ${item.itemName == '-' ? '| Vanilla' : ''}`}
                             </Typography>
-
-                            {'floatShort' in item && item.floatShort &&
-                                <Typography
-                                    variant='h5'
-                                    fontWeight={600}>
-                                    ({fullFloatCategoryName(item.floatShort)})
-                                </Typography>
-                            }
 
                         </div>
 
@@ -112,7 +83,7 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
                             <div className='item-image'>
                                 <img
                                     src={item.imageUrl}
-                                    alt={item.name}
+                                    alt={item.fullItemName}
                                     loading='lazy'
                                 />
                             </div>
@@ -121,21 +92,23 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
                                 <Stack direction='row' spacing={2} justifyContent='space-between'>
 
                                     <Link
-                                        href='#'
+                                        href={item.inspectUrl}
+                                        target='_blank'
                                         underline='none'
                                     >
                                         Inspecionar <FaExternalLinkAlt />
                                     </Link>
 
                                     <Link
-                                        href='#'
+                                        href={'https://steamcommunity.com/market/listings/730/' + item.fullItemName}
+                                        target='_blank'
                                         underline='none'
                                     >
                                         Ver na Steam <FaExternalLinkAlt />
                                     </Link>
 
                                     <Link
-                                        href={`https://youtube.com/results?search_query=CS2 ${'subCategory' in item && item.subCategory} ${item.name} - Skin Float And Wear Preview`}
+                                        href={`https://youtube.com/results?search_query=${item.weaponType} ${item.itemName == '-' ? 'Vanilla' : item.itemName} - Skin Float And Wear Preview`}
                                         target='_blank'
                                         underline='none'
                                     >
@@ -145,7 +118,7 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
                                 </Stack>
                             </div>
 
-                            {'stickerArray' in item && (
+                            {item.weaponType.toLowerCase() !== 'sticker' && item.stickers.length > 0 &&
 
                                 <Stack
                                     direction='row'
@@ -155,15 +128,15 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
                                     gridTemplateColumns={'repeat(4, 1fr)'}
                                     height={'90px'}
                                 >
-                                    {item.stickerArray.map((sticker) => {
+                                    {item.stickers.slice(0, 4).map((sticker, index) => { //TODO: slicing 4 stickers
                                         return (
                                             <Tooltip
-                                                key={sticker.id}
+                                                key={sticker.stickerId + '-' + index}
                                                 placement='top'
                                                 arrow
                                                 title={
                                                     <Typography noWrap minWidth='fit-content'>
-                                                        {sticker.category} | {sticker.name} | {sticker.eventOrCollection}
+                                                        {sticker.name}
                                                     </Typography>
                                                 }>
                                                 <div className='item-sticker'>
@@ -173,7 +146,7 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
                                                         loading='lazy'
                                                     />
                                                     <Typography>
-                                                        R${sticker.price}
+                                                        R${9999 /*TODO: mocking*/}
                                                     </Typography>
                                                 </div>
                                             </Tooltip>
@@ -181,7 +154,7 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
                                     })}
                                 </Stack>
 
-                            )}
+                            }
 
                         </div>
 
@@ -189,36 +162,28 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
 
                             <div className='item-details-box float'>
 
-                                {'floatFull' in item && 'floatShort' &&
-
-                                    <>
-
-                                        <div className='float-container'>
-                                            <FloatBar floatValue={item.floatFull * 100} />
-                                        </div>
+                                <div className='float-container'>
+                                    <FloatBar floatValue={item.floatValue * 100} />
+                                </div>
 
 
-                                        <div className='item-info'>
+                                <div className='item-info'>
 
-                                            <div className='item-field'>
-                                                <Typography>
-                                                    Float
-                                                </Typography>
-                                            </div>
+                                    <div className='item-field'>
+                                        <Typography>
+                                            Float
+                                        </Typography>
+                                    </div>
 
-                                            <div className='item-value'>
-                                                <Typography>
-                                                    {item.floatFull}
-                                                </Typography>
-                                            </div>
+                                    <div className='item-value'>
+                                        <Typography>
+                                            {item.floatValue}
+                                        </Typography>
+                                    </div>
 
-                                        </div>
+                                </div>
 
-                                        <Divider sx={{ bgcolor: '#BCBCC2' }} />
-
-                                    </>
-
-                                }
+                                <Divider sx={{ bgcolor: '#BCBCC2' }} />
 
                                 <div className='item-info'>
 
@@ -234,18 +199,16 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
 
                                     <div className='item-value'>
                                         <Typography>
-                                            Oculto {/*TODO: MOCKING*/}
+                                            {item.rarityName}
                                         </Typography>
                                         <Typography>
-                                            541 {/*TODO: MOCKING*/}
+                                            {item.paintSeed}
                                         </Typography>
                                     </div>
 
                                 </div>
 
                             </div>
-
-
 
                             <div className='item-details-box price'>
 
@@ -260,11 +223,9 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
                                         </Typography>
                                     </div>
 
-
-
                                     <div className='item-value'>
                                         <Typography>
-                                            R$ {item.steamPrice}
+                                            R$ {item.steamPrice.toFixed(2)}
                                         </Typography>
                                         <Typography>
                                             R$ {(item.steamPrice / 100 * 85).toFixed(2)}
@@ -285,7 +246,7 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
 
                                     <div className='item-value'>
                                         <Typography variant='h6'>
-                                            R$ {item.price}
+                                            R$ {item.price.toFixed(2)}
                                         </Typography>
                                     </div>
 
@@ -293,7 +254,7 @@ const ItemModal = ({ item, open, handleClose, itemAction }: ItemModalProps) => {
 
                                 <div className='add-cart-container'>
                                     <AddCartButton
-                                        isItemInCart={isItemInCart(item.id)}
+                                        isItemInCart={isItemInCart(item.assetId)}
                                         onClick={itemAction}
                                         isHovered={true}
                                     />

--- a/frontend/poletto_skins/src/contexts/CartContext.tsx
+++ b/frontend/poletto_skins/src/contexts/CartContext.tsx
@@ -1,11 +1,11 @@
-import { ItemType } from '@/types/entities/item'
+import { MarketItem } from '@/types/entities/steam-item'
 import { createContext, ReactNode, useState } from 'react'
 
 type CartContextValue = {
-    cart: ItemType[]
-    isItemInCart: (itemId: ItemType['id']) => boolean
-    addToCart: (item: ItemType) => void
-    removeFromCart: (itemId: ItemType['id']) => void
+    cart: MarketItem[]
+    isItemInCart: (itemId: MarketItem['assetId']) => boolean
+    addToCart: (item: MarketItem) => void
+    removeFromCart: (itemId: MarketItem['assetId']) => void
     clearCart: () => void
     totalItems: number
     totalPrice: number
@@ -27,20 +27,20 @@ type CartProviderProps = {
 
 export const CartProvider = ({ children }: CartProviderProps) => {
 
-    const [cart, setCart] = useState<ItemType[]>([])
+    const [cart, setCart] = useState<MarketItem[]>([])
 
-    const isItemInCart = (itemId: ItemType['id']) => {
-        return cart.some((item) => item.id === itemId)
+    const isItemInCart = (itemId: MarketItem['assetId']) => {
+        return cart.some((item) => item.assetId === itemId)
     }
 
-    const addToCart = (item: ItemType) => {
-        if (!isItemInCart(item.id)) {
+    const addToCart = (item: MarketItem) => {
+        if (!isItemInCart(item.assetId)) {
             setCart([...cart, item])
         }
     }
 
-    const removeFromCart = (itemId: ItemType['id']) => {
-        setCart(cart.filter((item) => item.id !== itemId))
+    const removeFromCart = (itemId: MarketItem['assetId']) => {
+        setCart(cart.filter((item) => item.assetId !== itemId))
     }
 
     const clearCart = () => setCart([])

--- a/frontend/poletto_skins/src/pages/Buy/index.tsx
+++ b/frontend/poletto_skins/src/pages/Buy/index.tsx
@@ -2,253 +2,11 @@ import Catalog from '@/components/Catalog'
 import MainFilter from '@/components/MainFilter'
 import TopFilter from '@/components/TopFilter'
 import { useCart } from '@/hooks/useCart'
-import { GloveSkin, ItemType, Sticker, WeaponSkin } from '@/types/entities/item'
-import axios from 'axios'
+import { get } from '@/services/api'
+import { MarketItem, SteamItem } from '@/types/entities/steam-item'
+import { Box } from '@mui/material'
 import { useCallback, useEffect, useState } from 'react'
 import './styles.scss'
-
-//MOCKS
-const fetchedStickersFromApi: Sticker[] = [
-    {
-        id: '0770f06f-d9a5-4a0d-9954-12596bd41eb1',
-        name: 'Titan',
-        category: 'Stickers',
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXQ9QVcJY8gulRYQV_bRvCiwMbQVg8kdFAYorOxKglf2_zEfnNA7oiyx9jdzqanZb3Txj8F7cZwie3CrNTwiVbl-hdrMj30dY-VewA5fxiOrQhGIm55',
-        price: 153.95,
-        steamPrice: 589.72,
-        discount: 74,
-        rarity: 'Remarkable',
-        finish: 'Holo',
-        eventOrCollection: 'Katowice 2014',
-        origin: 'Capsule'
-    },
-    {
-        id: 'f0fe428a-ed24-4565-a796-d4655a885c08',
-        name: 'Virtus.Pro',
-        category: 'Stickers',
-        imageUrl: 'https://community.akamai.steamstatic.com/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXQ9QVcJY8gulRYX0DbRvCiwMbQVg8kdFEYoLO3PxJzw-HHTjtN5dD4ktPflvP1Z-vVkG5TsJUi2eqZp4jz2Qay_hdkMW-nINPDJFI5ZFnR_0_-n7lgPHan2Q',
-        price: 200.00,
-        steamPrice: 650.00,
-        discount: 69,
-        rarity: 'Remarkable',
-        finish: 'Foil',
-        eventOrCollection: 'Katowice 2015',
-        origin: 'Capsule'
-    },
-    {
-        id: '35cc5927-7848-441c-aa8f-02d551744fd3',
-        name: 'Natus Vincere',
-        category: 'Stickers',
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXQ9QVcJY8gulReQ0DfQOqohZ-CBRJ6JBJeibKqJwgu0vWZIjwUuIvlwNiOwaKmZLqGxjkD7pUh3OrC843w2wOy-UpqYW7yJ5jVLFH30XxDQQ',
-        price: 180.00,
-        steamPrice: 600.00,
-        discount: 71,
-        rarity: 'Remarkable',
-        finish: 'Holo',
-        eventOrCollection: 'Cologne 2016',
-        origin: 'Capsule'
-    },
-    {
-        id: '0582b082-52cb-423b-808c-3acdeddd30d0',
-        name: 'Crown',
-        category: 'Stickers',
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXQ9QVcJY8gulROWEXTTOG_xJ2cUE97MgposLWsJ0lli6uRJ2sTvoqywYONkaH2Nb-Gl28G6cByiO_Hp9333QywqBE-amihOsbLJUJKMhul',
-        price: 190.00,
-        steamPrice: 630.00,
-        discount: 65,
-        rarity: 'Exotic',
-        finish: 'Foil',
-        eventOrCollection: 'Sticker Capsule 2',
-        origin: 'Capsule'
-    }
-]
-
-const fetchedWeaponSkinsFromApi: WeaponSkin[] = [
-    {
-        id: '5e232b24-f940-47d8-ad9d-8c776ba61629',
-        name: 'Neon Rider',
-        category: 'Rifles',
-        subCategory: 'AK-47',
-        statTrak: true,
-        floatShort: 'MW',
-        floatFull: 0.09875,
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DEVlxkKgpot7HxfDhjxszJegJM6dO4q5KCk_LmDLfYkWNFppYojOvFpdj20QKxqEY_a2r1cIadIwdoMl3Q8lG9l7y7g5C5u5nIznJ9-n51YP1b6DQ',
-        stickerArray: fetchedStickersFromApi,
-        discount: 22,
-        price: 2389.45,
-        steamPrice: 2752.73
-    },
-    {
-        id: '4ce8f3da-2a8f-4e75-9228-6e41739b95bb',
-        name: 'Dragon Lore',
-        category: 'Sniper Rifles',
-        subCategory: 'AWP',
-        statTrak: false,
-        floatShort: 'FN',
-        floatFull: 0.02,
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DEVlxkKgpot621FAR17P7NdTRH-t26q4SZlvD7PYTQgXtu5Mx2gv2PrdSijAWwqkVtN272JIGdJw46YVrYqVO3xLy-gJC9u5vByCBh6ygi7WGdwUKTYdRD8A',
-        stickerArray: [fetchedStickersFromApi[0], fetchedStickersFromApi[3]],
-        discount: 10,
-        price: 15000.00,
-        steamPrice: 18000.00
-    },
-    {
-        id: '38ee3a14-97dc-4328-b5f4-b9eba187d0aa',
-        name: 'Asiimov',
-        category: 'Rifles',
-        subCategory: 'M4A4',
-        statTrak: false,
-        floatShort: 'FT',
-        floatFull: 0.165,
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DEVlxkKgpou-6kejhjxszFJQJD_9W7m5a0mvLwOq7c2GpQ7JMg0uyYoYin2wHj-kU6YGD0cYOUcFA9YFnS_AC9xeq508K0us7XiSw0vgXM_Rw',
-        stickerArray: [fetchedStickersFromApi[1], fetchedStickersFromApi[0]],
-        discount: 15,
-        price: 5000.00,
-        steamPrice: 5500.00
-    },
-    {
-        id: '6756535d-c686-4b04-96de-a1239d5e3643',
-        name: 'Printstream',
-        category: 'Rifles',
-        subCategory: 'M4A1-S',
-        statTrak: true,
-        floatShort: 'FN',
-        floatFull: 0.029,
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DEVlxkKgpou-6kejhz2v_Nfz5H_uO1gb-Gw_alIITBhGJf_NZlmOzA-LP5gVO8v11qa2n6dtOcIQVoMFHUqwC9wei7jcO5vZ3AzSQ1vCMls3fayxKyhh1McKUx0sfzkVMr',
-        stickerArray: [],
-        discount: 21,
-        price: 4560.06,
-        steamPrice: 5523.05
-    },
-    {
-        id: '299f1fc7-3a9f-4381-b1b1-818417efbc03',
-        name: 'Ocean Drive',
-        category: 'Pistols',
-        subCategory: 'Desert Eagle',
-        statTrak: false,
-        floatShort: 'MW',
-        floatFull: 0.093,
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DEVlxkKgposr-kLAtl7PDdTjlH7du6kb-AnuP3O4Tdn2xZ_Ity0-qSptum3gbs_kNtZD31LdedIw5qNFHRrle3wrrs1sXpu8jNyHNhpGB8sqEwmZLd',
-        stickerArray: [],
-        discount: 9,
-        price: 575.14,
-        steamPrice: 591.70
-    },
-    {
-        id: 'db5f59ff-22ec-43b5-9703-2840c08f0af4',
-        name: 'Atheris',
-        category: 'Rifles',
-        subCategory: 'AWP',
-        statTrak: true,
-        floatShort: 'BS',
-        floatFull: 0.813,
-        imageUrl: 'https://community.akamai.steamstatic.com/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DEVlxkKgpot621FAR17PLfYQJU5cyzhr-DkvbiKvWCkG4Gucd1jrmR9t_z2VewrkBkMTjzIdCWewBsaFuBrwW2xem7hpe9ot2Xnv5EhL7X',
-        stickerArray: [],
-        discount: 0,
-        price: 15.38,
-        steamPrice: 11.49
-    }
-]
-
-const fetchedGloveSkinsFromApi: GloveSkin[] = [
-    {
-        id: '8f42ab8b-28a6-4bdc-9236-151dfec670e1',
-        name: 'Vice',
-        category: 'Gloves',
-        subCategory: 'Sport Gloves',
-        floatShort: 'FN',
-        floatFull: 0.00521,
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DAQ1JmMR1osbaqPQJz7ODYfi9W9eO0mJWOqOf9PbDummJW4NE_3LmYo43w31Cx-xE4ZmilJoWVdFRvNQzX_1DtlLjq15G5tJnLzCFh7j5iuyjrgJbKOg',
-        price: 93994.25,
-        steamPrice: 123655.08,
-        discount: 24
-    },
-    {
-        id: '3b59556a-c7ab-48c1-859c-c102b6a08dc5',
-        name: 'Cobalt Skulls',
-        category: 'Gloves',
-        subCategory: 'Hand Wraps',
-        floatShort: 'MW',
-        floatFull: 0.08234,
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DfVlxgLQFFibKkJQN3wfLYYgJK7dKyg5KKh8j4NrrFnm5D8fp3i-vT_I_KilihriwvOCyveMX6Ll9pORzOrFe6xu6-hce47c_MwHZk6CRxtCrdnBDi1x9Ea-xr0fGaS1XNUvdLH77CWCR9IaxTog',
-        price: 75000.00,
-        steamPrice: 85000.00,
-        discount: 12
-    },
-    {
-        id: '0c241296-e707-4474-89d9-eeae4f55d54f',
-        name: 'Fade ',
-        category: 'Gloves',
-        subCategory: 'Specialist Gloves',
-        floatShort: 'FT',
-        floatFull: 0.15867,
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DAQ1h3LAVbv6mxFABs3OXNYgJR_Nm1nYGHnuTgDL3Qkm5u5Mx2gv2PpdWi3QGy-BY-YW6gcI6Vc1c5Z17RqADtxe7p0Z7qtJnLnHsxuCIk52GdwUIAanvipQ',
-        price: 80000.00,
-        steamPrice: 90000.00,
-        discount: 11
-    },
-    {
-        id: 'bf054871-5698-4791-b060-f4a90c5d4e38',
-        name: 'Shemagh Escarlate',
-        category: 'Gloves',
-        subCategory: 'Sport Gloves',
-        floatShort: 'WW',
-        floatFull: 0.41,
-        imageUrl: 'https://community.akamai.steamstatic.com/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DAQ1JmMR1osbaqPQJz7ODYfi9W9eO-m5WFk-TgPLTFnlRD7cFOh-zF_Jn4xg2xqBdlaz_1LILDI1U6MFDTrFXsyOi7jcC97pXOyydkuSRw537UnR2pwUYbvu3uoFg',
-        discount: 17,
-        price: 1300.15,
-        steamPrice: 1570.92
-    }
-]
-
-const fetchedKnifeSkinsFromApi: ItemType[] = [
-    {
-        id: '4f4e014a-2980-4c15-b05f-55c2ab477168',
-        name: 'Fade',
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DEVlxkKgpovbSsLQJf2PLacDBA5ciJlYG0kfbwNoTdn2xZ_Isn3uyTpN7zjlHt-ENsZjumcoCUJAZqaV_QqVa9xL3thsC-tZyYznIypGB8sly_Gx3i',
-        price: 13959.49,
-        steamPrice: 14605.79,
-        discount: 4,
-        category: 'Knifes',
-        subCategory: 'Karambit',
-        statTrak: true,
-        floatShort: 'FN',
-        floatFull: 0.021
-    },
-    {
-        id: '3c7e6361-3dc2-4253-848b-90953a5c65f4',
-        name: 'Crimson Web',
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DEVlxkKgpovbSsLQJf3qr3czxb49KzgL-DjsjjNrnCqWZU7Mxkh6fAp9X20APgrRc5YW76I46XcwM-Mw2B_AS5kunm08Pt6Z3MnCZruSAr-z-DyMcCNLCI',
-        price: 15450.00,
-        steamPrice: 16000.00,
-        discount: 5,
-        category: 'Knifes',
-        subCategory: 'M9 Bayonet',
-        statTrak: false,
-        floatShort: 'FT',
-        floatFull: 0.159
-    },
-    {
-        id: '74cd450f-1618-4c7f-83df-482663e443f9',
-        name: 'Ultraviolet',
-        imageUrl: 'https://steamcommunity-a.akamaihd.net/economy/image/-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxDZ7I56KU0Zwwo4NUX4oFJZEHLbXH5ApeO4YmlhxYQknCRvCo04DEVlxkKgpovbSsLQJf0ebcZThQ6tCvq5OEqOfhIavdk1Rd4cJ5nqeX99zwiQftqBFpYGzwIteVcwNtZ1jW_Vbvw-bsg5G1tMiamHU2syVz-z-DyAONDlVx',
-        price: 14500.00,
-        steamPrice: 15000.00,
-        discount: 3,
-        category: 'Knifes',
-        subCategory: 'Butterfly',
-        statTrak: false,
-        floatShort: 'MW',
-        floatFull: 0.084
-    }
-]
-
-const combinedArray: ItemType[] = [
-    ...fetchedWeaponSkinsFromApi,
-    ...fetchedStickersFromApi,
-    ...fetchedGloveSkinsFromApi,
-    ...fetchedKnifeSkinsFromApi
-]
 
 type FilterData = {
     minPrice?: string,
@@ -266,17 +24,17 @@ const Buy = () => {
 
     const { addToCart, removeFromCart, isItemInCart } = useCart()
 
-    const handleAddCartButtonClick = (item: ItemType) => {
-        if (isItemInCart(item.id)) {
-            removeFromCart(item.id)
+    const handleAddCartButtonClick = (item: MarketItem) => {
+        if (isItemInCart(item.assetId)) {
+            removeFromCart(item.assetId)
         } else {
             addToCart(item)
         }
     }
 
-    const [items, setItems] = useState<ItemType[]>([])
+    const [items, setItems] = useState<MarketItem[]>([])
 
-    const [filterData, setFilterData] = useState<FilterData>()
+    const [/*filterData*/, setFilterData] = useState<FilterData>()
 
     const handleFilterChange = (data: FilterData) => {
         setFilterData(prevFilterData => ({
@@ -285,48 +43,68 @@ const Buy = () => {
         }))
     }
 
-    const sendApiRequest = useCallback(async () => {
+    const getUserItems = useCallback(async () => {
+        try {
 
-        if (!filterData) return
+            const mockSteamId = '76561198191317871'
 
-        //testing only
-        const response = await axios.get('https://jsonplaceholder.typicode.com/posts', {
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            params: filterData
-        })
+            const steamItemsFromUser = await get<SteamItem[]>('/getPlayerInventory', { steamId: mockSteamId })
 
-        await response.data
+            // Mocking prices
+            const marketItems = steamItemsFromUser.map(item => ({
+                ...item,
+                price: Math.random() * 100,
+                steamPrice: Math.random() * 100,
+                discount: Math.random() > 0.5 ? Math.random() * 20 : undefined
+            }))
 
-        setItems(combinedArray)
-    }, [filterData])
+            setItems(marketItems)
+        } catch (error) {
+            console.error(`Error trying to fetch steam user data: ${error}`)
+        }
+    }, [])
 
     useEffect(() => {
-        sendApiRequest()
-    }, [sendApiRequest])
+        getUserItems()
+    }, [getUserItems])
 
     return (
 
-        <div className='buy-main-container'>
+        <Box
+            display={'flex'}
+            flexDirection={'row'}
+            gap={2}
+            height={'100%'}
+            width={'100%'}
+            bgcolor={'#292733'}
+            borderRadius={'5px'}
+            p={2}
+        >
+            <MainFilter onFilterChange={handleFilterChange} />
 
-            <div className='main-filter'>
-                <MainFilter onFilterChange={handleFilterChange} />
-            </div>
-
-            <div className='buy-main-area'>
-
+            <Box
+                gap={2}
+                display={'flex'}
+                height={'100%'}
+                width={'100%'}
+                flexDirection={'column'}
+            >
                 <div className='top-filter'>
                     <TopFilter onFilterChange={handleFilterChange} />
                 </div>
 
-                <div className='catalog-container'>
+                <Box
+                    sx={{
+                        overflowY: 'auto',
+                        overflowX: 'hidden'
+                    }}
+                >
                     <Catalog items={items} itemAction={handleAddCartButtonClick} />
-                </div>
+                </Box>
 
-            </div>
+            </Box>
 
-        </div>
+        </Box>
 
     )
 

--- a/frontend/poletto_skins/src/pages/Home/index.tsx
+++ b/frontend/poletto_skins/src/pages/Home/index.tsx
@@ -20,10 +20,6 @@ const Home = () => {
 
             </div>
 
-            <div className='operation-container'>
-
-            </div>
-
         </div>
 
     )

--- a/frontend/poletto_skins/src/pages/Home/styles.scss
+++ b/frontend/poletto_skins/src/pages/Home/styles.scss
@@ -13,9 +13,9 @@ $primary-box-shadow-hover: 0 0 10px $accent-color, 0 0 15px rgba($accent-color, 
     box-sizing: border-box;
 
     .central-container {
-        background-color: $background-color;
-        padding: 16px;
-        border-radius: 5px;
+        //background-color: $background-color;
+        //padding: 16px;
+        //border-radius: 5px;
         width: 100%;
     }
 

--- a/frontend/poletto_skins/src/pages/Sell/index.tsx
+++ b/frontend/poletto_skins/src/pages/Sell/index.tsx
@@ -1,13 +1,110 @@
+import Catalog from '@/components/Catalog'
+import TopFilter from '@/components/TopFilter'
+import { useAuth } from '@/hooks/useAuth'
+import { useCart } from '@/hooks/useCart'
+import { get } from '@/services/api'
+import { MarketItem, SteamItem } from '@/types/entities/steam-item'
+import { Box, Typography } from '@mui/material'
+import { useCallback, useEffect, useState } from 'react'
 
+type FilterData = {
+    minPrice?: string,
+    maxPrice?: string,
+    minFloat?: string,
+    maxFloat?: string,
+    category?: string[],
+    others?: string[],
+    query?: string,
+    sort?: string,
+    favorite?: boolean
+}
 
 const Sell = () => {
 
+    const { steamId } = useAuth()
+
+    const { addToCart, removeFromCart, isItemInCart } = useCart()
+
+    const handleAddCartButtonClick = (item: MarketItem) => {
+        if (isItemInCart(item.assetId)) {
+            removeFromCart(item.assetId)
+        } else {
+            addToCart(item)
+        }
+    }
+
+    const [items, setItems] = useState<MarketItem[]>([])
+
+    const [/*filterData*/, setFilterData] = useState<FilterData>()
+
+    const handleFilterChange = (data: FilterData) => {
+        setFilterData(prevFilterData => ({
+            ...prevFilterData,
+            ...data
+        }))
+    }
+
+    const getUserItems = useCallback(async (steamId: string) => {
+        try {
+            const steamItemsFromUser = await get<SteamItem[]>('/getPlayerInventory', { steamId })
+
+            // Mocking prices
+            const marketItems = steamItemsFromUser.map(item => ({
+                ...item,
+                price: Math.random() * 100,
+                steamPrice: Math.random() * 100,
+                discount: Math.random() > 0.5 ? Math.random() * 20 : undefined,
+            }))
+
+            setItems(marketItems)
+        } catch (error) {
+            console.error(`Error trying to fetch steam user data: ${error}`)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (steamId) {
+            getUserItems(steamId)
+        }
+    }, [getUserItems, steamId])
+
     return (
-        <>
 
-            <span>SELL SECTION</span>
+        <Box display={'flex'} flexDirection={'row'} gap={2} height={'100%'}>
 
-        </>
+            <Box
+                gap={2}
+                display={'flex'}
+                height={'100%'}
+                width={'100%'}
+                flexDirection={'column'}
+                bgcolor={'#292733'}
+                borderRadius={'5px'}
+                p={2}
+            >
+                <div className='top-filter'>
+                    <TopFilter onFilterChange={handleFilterChange} />
+                </div>
+
+                <Box
+                    sx={{
+                        overflowY: 'auto',
+                        overflowX: 'hidden'
+                    }}
+                >
+                    <Catalog items={items} itemAction={handleAddCartButtonClick} />
+                </Box>
+
+            </Box>
+
+            <Box>
+                <Typography variant='body1'>
+                    Lista de Venda
+                </Typography>
+            </Box>
+
+        </Box>
+
     )
 
 }

--- a/frontend/poletto_skins/src/types/entities/steam-item.d.ts
+++ b/frontend/poletto_skins/src/types/entities/steam-item.d.ts
@@ -1,0 +1,46 @@
+type SteamItem = {
+    assetId: string
+    ownerSteamId: string
+    d: string
+    m: string
+    origin: number
+    quality: number
+    rarity: number
+    paintSeed: number
+    defIndex: number
+    paintIndex: number
+    floatId: string
+    lowRank: string
+    highRank: string
+    floatValue: number
+    imageUrl: string
+    inspectUrl: string
+    min: number
+    max: number
+    weaponType: string
+    itemName: string
+    rarityName: string
+    qualityName: string
+    originName: string
+    wearName: string
+    fullItemName: string
+    stickers: SteamSticker[]
+}
+
+type SteamSticker = {
+    stickerId: number
+    slot: number
+    imageUrl: string
+    wear: number
+    scale: number
+    rotation: number
+    codename: string
+    material: string
+    name: string
+}
+
+export type MarketItem = SteamItem & {
+    price: number
+    steamPrice: number
+    discount?: number
+}

--- a/frontend/poletto_skins/src/utils/extractStickerFinish.ts
+++ b/frontend/poletto_skins/src/utils/extractStickerFinish.ts
@@ -1,0 +1,4 @@
+export const extractStickerFinish = (text: string) => {
+    const match = text.match(/\(([^)]+)\)/)
+    return match ? match[1] : null
+}

--- a/frontend/poletto_skins/src/utils/itemWearAbbreviator.ts
+++ b/frontend/poletto_skins/src/utils/itemWearAbbreviator.ts
@@ -1,0 +1,18 @@
+export type WearName = 'Factory New' | 'Minimal Wear' | 'Field-Tested' | 'Well-Worn' | 'Battle-Scarred'
+
+export const itemWearAbbreviator = (wearName: WearName): string => {
+    switch (wearName) {
+        case 'Factory New':
+            return 'FN'
+        case 'Minimal Wear':
+            return 'MW'
+        case 'Field-Tested':
+            return 'FT'
+        case 'Well-Worn':
+            return 'WW'
+        case 'Battle-Scarred':
+            return 'BS'
+        default:
+            return ''
+    }
+}


### PR DESCRIPTION
Esse pull request integra as alterações feitas na branch adapting-client-to-receive-api-items que incluem mas não se limitam a:

* Criar nova type no frontend para dar match nas propriedades de cada item retornadas da API 51bb816
* Trocando o type de itens em todos componentes que usavam a ItemType, fazendo as devidas adaptações nos métodos e pârametros f982f86
* Dando início a construção da página Sell que irá buscar os itens do usuário logado no site e exibir os que possuem disponibilidade para venda, o componente SellList só foi posicionado no container da Sell mas ainda não foi construído 4aee06c
* Removendo estilos da Home, delegando para que cada página children (Sell, Buy, etc...) possam customizar a sua maneira, devido a maneira como podem existir elementos fora do catalog-container 832b2b7 e cb8ae22
* Adicionado funções auxiliares para abreviar nomes de float (Factory New => FN) e também para extrair tipo de finalização dos stickers mas isso é algo que potencialmente deveria ser feito no backend 0babe73 e d349f1d
* Mudanças no backend para incluir url de imagem dos stickers também, substituir imagem do item do response da CsFloat pelo da Steam pois a qualidade é bem melhor (closes #19), filtrando itens retornados da Steam para reduzir carga do serviço da CsFloat, trocando nome de algumas propriedades das entidades 484495c, 285463c e 775bca8.